### PR TITLE
Implement Firestore booking submission

### DIFF
--- a/lib/features/booking/services/booking_service.dart
+++ b/lib/features/booking/services/booking_service.dart
@@ -1,10 +1,11 @@
-import 'package:flutter/foundation.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import '../models/booking.dart';
 
 class BookingService {
+  final CollectionReference bookingsRef =
+      FirebaseFirestore.instance.collection('bookings');
+
   Future<void> submitBooking(Booking booking) async {
-    await Future.delayed(const Duration(milliseconds: 500));
-    debugPrint('📅 Booking saved: ${booking.toJson()}');
-    // TODO: Replace with Firestore integration
+    await bookingsRef.add(booking.toJson());
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   json_annotation: ^4.8.1
   flutter_bloc: ^8.1.4
   equatable: ^2.0.5
+  cloud_firestore: ^5.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- connect booking service to Firestore
- add `cloud_firestore` to pubspec dependencies

## Testing
- `../flutter_sdk/bin/flutter pub get`
- `../flutter_sdk/bin/flutter test`

------
https://chatgpt.com/codex/tasks/task_e_684ca53faa408324866ec17c7e88ee34