### PR TITLE
Add Firestore booking table

### DIFF
--- a/lib/features/business/screens/business_dashboard_screen.dart
+++ b/lib/features/business/screens/business_dashboard_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 class BusinessDashboardScreen extends StatelessWidget {
   const BusinessDashboardScreen({super.key});
@@ -20,6 +21,8 @@ class BusinessDashboardScreen extends StatelessWidget {
             ),
             const SizedBox(height: 20),
             const Text('\uD83D\uDCC5 Bookings'),
+            const SizedBox(height: 10),
+            const BookingTableWidget(),
             const Divider(),
             const Text('\uD83E\uDDD1 Staff Availability'),
             const Divider(),
@@ -29,6 +32,45 @@ class BusinessDashboardScreen extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+class BookingTableWidget extends StatelessWidget {
+  const BookingTableWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<QuerySnapshot>(
+      stream: FirebaseFirestore.instance
+          .collection('bookings')
+          .orderBy('dateTime')
+          .snapshots(),
+      builder: (context, snapshot) {
+        if (snapshot.hasError) return const Text('Error loading bookings');
+        if (!snapshot.hasData) return const CircularProgressIndicator();
+
+        final bookings = snapshot.data!.docs;
+
+        if (bookings.isEmpty) return const Text('No bookings yet');
+
+        return DataTable(
+          columns: const [
+            DataColumn(label: Text('Date')),
+            DataColumn(label: Text('Notes')),
+          ],
+          rows: bookings.map((doc) {
+            final data = doc.data() as Map<String, dynamic>;
+            final date =
+                DateTime.tryParse(data['dateTime'] ?? '') ?? DateTime.now();
+            final notes = data['notes'] ?? '';
+            return DataRow(cells: [
+              DataCell(Text(date.toLocal().toString())),
+              DataCell(Text(notes)),
+            ]);
+          }).toList(),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- show bookings on business dashboard using Firestore
- include a simple `BookingTableWidget` for listing records

## Testing
- `flutter test` *(fails: storage.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684cb25bbb1483249d7d08d1d6add7e1