### PR TITLE
Finalize business dashboard integration

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'features/booking/screens/booking_screen.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'firebase_options.dart';
+import 'features/business/screens/business_dashboard_screen.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
   runApp(const ProviderScope(child: App()));
 }
 
@@ -12,32 +18,9 @@ class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'APP-OINT',
-      debugShowCheckedModeBanner: false,
-      theme: ThemeData(
-        useMaterial3: true,
-        colorSchemeSeed: Colors.indigo,
-      ),
-      initialRoute: '/booking',
-      routes: {
-        '/booking': (context) => const BookingScreen(),
-      },
-    );
-  }
-}
-
-class PlaceholderScreen extends StatelessWidget {
-  const PlaceholderScreen({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: Text(
-          'Welcome to APP-OINT',
-          style: TextStyle(fontSize: 20),
-        ),
-      ),
+      title: 'Appoint',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const BusinessDashboardScreen(),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   flutter_bloc: ^8.1.4
   equatable: ^2.0.5
   cloud_firestore: ^5.4.0
+  firebase_core: ^2.24.0
 
 dev_dependencies:
   flutter_test:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,9 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
 import 'package:appoint/main.dart';
 
 void main() {
-  testWidgets('App starts without errors', (WidgetTester tester) async {
+  testWidgets('App smoke test', (WidgetTester tester) async {
     await tester.pumpWidget(const App());
-    expect(find.byType(App), findsOneWidget);
+    expect(find.text('Business Dashboard'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- initialize Firebase before running the app
- show the business dashboard by default
- add firebase_core dependency
- add a widget test checking Business Dashboard text

## Testing
- `dart format .`
- `flutter pub get` *(fails: network access blocked)*
- `flutter pub run build_runner build --delete-conflicting-outputs` *(fails: network access blocked)*
- `flutter analyze` *(fails: network access blocked)*
- `flutter test` *(fails: couldn't resolve Flutter SDK dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684cbb0978088324946e6008ab0473aa