### PR TITLE
Restore DateTime converter and add sync script

### DIFF
--- a/lib/utils/datetime_converter.dart
+++ b/lib/utils/datetime_converter.dart
@@ -1,0 +1,12 @@
+import 'package:json_annotation/json_annotation.dart';
+
+/// A custom converter to handle DateTime serialization in @JsonKey.
+class DateTimeConverter implements JsonConverter<DateTime, String> {
+  const DateTimeConverter();
+
+  @override
+  DateTime fromJson(String json) => DateTime.parse(json);
+
+  @override
+  String toJson(DateTime object) => object.toIso8601String();
+}

--- a/sync_and_rebuild.sh
+++ b/sync_and_rebuild.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+echo "🔄 Pulling latest from GitHub..."
+git pull origin main
+
+echo "🧹 Cleaning project..."
+flutter clean
+dart pub get
+
+echo "🔁 Running build_runner..."
+flutter pub run build_runner build --delete-conflicting-outputs
+
+echo "🧪 Analyzing project..."
+flutter analyze | tee fresh_reindex.txt


### PR DESCRIPTION
## Summary
- bring back `DateTimeConverter`
- add `sync_and_rebuild.sh` to refresh build and analysis

## Testing
- `./sync_and_rebuild.sh` *(fails: `origin` remote missing and `flutter` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ef266362883249362f29c35194c39