### PR TITLE
Add GitHub Codespaces support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "Flutter Dev",
+  "image": "ghcr.io/cirruslabs/flutter:latest",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dart-code.flutter",
+        "dart-code.dart-code"
+      ]
+    }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "flutter doctor && dart pub get && flutter pub get",
+  "remoteUser": "root"
+}

--- a/analyze_in_codespace.sh
+++ b/analyze_in_codespace.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+echo "🧼 Cleaning..."
+flutter clean
+
+echo "📦 Getting packages..."
+dart pub get
+flutter pub get
+
+echo "🛠️ Running build_runner..."
+flutter pub run build_runner build --delete-conflicting-outputs
+
+echo "🔍 Analyzing..."
+flutter analyze | tee fresh_reindex.txt


### PR DESCRIPTION
## Summary
- add devcontainer for GitHub Codespaces
- add helper analysis script

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684f1be6d6e483248d7eaf0dbefcbb88