### PR TITLE
Fix AppointApp test

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,7 +11,16 @@ void main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
-  runApp(const ProviderScope(child: MyApp()));
+  runApp(const AppointApp());
+}
+
+class AppointApp extends StatelessWidget {
+  const AppointApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const ProviderScope(child: MyApp());
+  }
 }
 
 class MyApp extends StatelessWidget {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,9 +1,17 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:firebase_core/firebase_core.dart';
 import 'package:appoint/main.dart';
+import 'package:appoint/firebase_options.dart';
 
 void main() {
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+  });
   testWidgets('App smoke test', (WidgetTester tester) async {
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const AppointApp());
     expect(find.text('Business Dashboard'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- update the widget test to use `AppointApp`
- expose `AppointApp` wrapper in `main.dart`

## Testing
- `flutter analyze`
- `flutter test test/widget_test.dart` *(fails: PlatformException(channel-error, Unable to establish connection on channel., null, null))*

------
https://chatgpt.com/codex/tasks/task_e_684f2c5f3888832483b43941f789c60b