### PR TITLE
Add Flutter localization support

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,6 @@
+{
+  "@@locale": "en",
+  "appTitle": "Appoint",
+  "welcome": "Welcome",
+  "bookMeeting": "Book a Meeting"
+}

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -1,0 +1,6 @@
+{
+  "@@locale": "he",
+  "appTitle": "אפפוינט",
+  "welcome": "ברוך הבא",
+  "bookMeeting": "קבע פגישה"
+}

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+class L10n {
+  static final all = [
+    const Locale('en'),
+    const Locale('he'),
+  ];
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'firebase_options.dart';
 import 'widgets/auth_wrapper.dart';
@@ -35,6 +37,13 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
       home: const AuthWrapper(),
       routes: {
         '/business-dashboard': (_) => const BusinessDashboardScreen(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+  intl: ^0.18.1
   firebase_core: ^2.27.0
   cloud_firestore: ^4.15.0
   firebase_auth: ^4.17.4
@@ -31,3 +34,4 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  generate: true


### PR DESCRIPTION
## Summary
- add `flutter_localizations` and `intl` dependencies
- create English and Hebrew translation files
- update app to register localization delegates
- include helper locale list

## Testing
- `flutter gen-l10n`
- `flutter analyze`
- `flutter test`
- `git push origin main` *(fails: repository not found)*

------
https://chatgpt.com/codex/tasks/task_e_68502712f2608324b25bbc0659295419