### PR TITLE
feat: premium logic and ad integration for booking confirmation

### DIFF
--- a/lib/features/booking/booking_confirm_screen.dart
+++ b/lib/features/booking/booking_confirm_screen.dart
@@ -7,6 +7,8 @@ import '../../providers/auth_provider.dart';
 import '../../providers/calendar_provider.dart';
 import '../../models/appointment.dart';
 import '../../providers/notification_provider.dart';
+import '../../providers/user_subscription_provider.dart';
+import '../../services/ad_service.dart';
 import 'models/booking_request_args.dart';
 
 class BookingConfirmScreen extends StatefulWidget {
@@ -51,6 +53,10 @@ class _BookingConfirmScreenState extends State<BookingConfirmScreen> {
               const Spacer(),
               ElevatedButton(
                 onPressed: () async {
+                  final isPremium = await ref.read(userSubscriptionProvider.future);
+                  if (!isPremium) {
+                    await AdService.showInterstitialAd();
+                  }
                   final user =
                       await ref.read(authServiceProvider).currentUser();
                   if (user == null) return;

--- a/lib/providers/user_subscription_provider.dart
+++ b/lib/providers/user_subscription_provider.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+final userSubscriptionProvider = FutureProvider<bool>((ref) async {
+  final uid = FirebaseAuth.instance.currentUser?.uid;
+  if (uid == null) return false;
+  final doc = await FirebaseFirestore.instance.collection('users').doc(uid).get();
+  return (doc.data()?['premium'] as bool?) ?? false;
+});

--- a/lib/services/ad_service.dart
+++ b/lib/services/ad_service.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+
+import 'package:google_mobile_ads/google_mobile_ads.dart';
+
+class AdService {
+  static const _testInterstitialAdId = 'ca-app-pub-3940256099942544/1033173712';
+
+  static Future<void> showInterstitialAd() async {
+    await MobileAds.instance.initialize();
+    final completer = Completer<void>();
+
+    await InterstitialAd.load(
+      adUnitId: _testInterstitialAdId,
+      request: const AdRequest(),
+      adLoadCallback: InterstitialAdLoadCallback(
+        onAdLoaded: (ad) {
+          ad.fullScreenContentCallback = FullScreenContentCallback(
+            onAdDismissedFullScreenContent: (ad) {
+              ad.dispose();
+              if (!completer.isCompleted) completer.complete();
+            },
+            onAdFailedToShowFullScreenContent: (ad, error) {
+              ad.dispose();
+              if (!completer.isCompleted) completer.complete();
+            },
+          );
+          ad.show();
+        },
+        onAdFailedToLoad: (error) {
+          if (!completer.isCompleted) completer.complete();
+        },
+      ),
+    );
+
+    await completer.future;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   json_annotation: ^4.8.1
   equatable: ^2.0.5
   flutter_bloc: ^8.1.4
+  google_mobile_ads: ^5.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- create `user_subscription_provider` to check user's premium status
- show an interstitial ad for free users via `AdService`
- use the new premium logic in `BookingConfirmScreen`
- add `google_mobile_ads` package

## Testing
- `flutter analyze` *(fails: analyzer version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_68509e19ae4c8324ac761dff50aceec7