### PR TITLE
Add CI workflow and update intl

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -1,0 +1,31 @@
+name: Flutter CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.19.0'
+          channel: 'stable'
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Generate code
+        run: flutter pub run build_runner build --delete-conflicting-outputs
+      - name: Analyze
+        run: flutter analyze
+      - name: Run tests
+        run: flutter test --coverage
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage/lcov.info

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -449,10 +449,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.1"
+    version: "0.20.2"
   io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  intl: ^0.18.1
+  intl: ^0.20.2
   google_mobile_ads: ^4.0.0
 
 dev_dependencies:
@@ -22,6 +22,9 @@ dev_dependencies:
   freezed: ^2.4.1
   json_serializable: ^6.7.1
   analyzer: ^6.2.0
+
+dependency_overrides:
+  intl: ^0.20.2
 
 flutter:
   uses-material-design: true

--- a/tool/codegen.sh
+++ b/tool/codegen.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+flutter pub run build_runner clean
+flutter pub run build_runner build --delete-conflicting-outputs


### PR DESCRIPTION
## Summary
- bump `intl` dependency to `^0.20.2`
- pin `intl` under `dependency_overrides`
- add a code generation script
- set up GitHub Actions workflow to build, test and upload coverage

## Testing
- `flutter pub get` *(fails: plugin google_mobile_ads requires Android V2 embedding)*
- `flutter pub run build_runner build --delete-conflicting-outputs`
- `flutter analyze` *(fails: plugin google_mobile_ads requires Android V2 embedding)*
- `flutter test --coverage` *(fails: plugin google_mobile_ads requires Android V2 embedding)*

------
https://chatgpt.com/codex/tasks/task_e_685168ca4dc4832487f477fcaabefa3c