### PR TITLE
Fix admin status chip and improve test Firebase setup

### DIFF
--- a/lib/features/admin/admin_broadcast_screen.dart
+++ b/lib/features/admin/admin_broadcast_screen.dart
@@ -249,7 +249,7 @@ class _AdminBroadcastScreenState extends ConsumerState<AdminBroadcastScreen> {
 
     return Chip(
       label: Text(text),
-      backgroundColor: color.withValues(alpha: 0.2),
+      backgroundColor: color.withOpacity(0.2),
       labelStyle: TextStyle(color: color),
     );
   }

--- a/test/booking_service_test.dart
+++ b/test/booking_service_test.dart
@@ -13,7 +13,7 @@ class MockCollectionReference extends Mock
 void main() {
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    registerFirebaseMock();
+    await registerFirebaseMock();
   });
 
   group('BookingService', () {

--- a/test/features/admin/admin_broadcast_screen_test.dart
+++ b/test/features/admin/admin_broadcast_screen_test.dart
@@ -16,7 +16,7 @@ late MockFirebaseFirestore mockFirestore;
 void main() {
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    registerFirebaseMock();
+    await registerFirebaseMock();
     mockFirestore = MockFirebaseFirestore();
     broadcastService = BroadcastService(firestore: mockFirestore);
     // Stub Firestore methods

--- a/test/features/admin/admin_role_test.dart
+++ b/test/features/admin/admin_role_test.dart
@@ -12,7 +12,7 @@ late MockFirebaseAuth mockAuth;
 void main() {
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    registerFirebaseMock();
+    await registerFirebaseMock();
     mockAuth = MockFirebaseAuth();
   });
 

--- a/test/features/auth/login_screen_test.dart
+++ b/test/features/auth/login_screen_test.dart
@@ -7,7 +7,7 @@ import 'package:appoint/features/auth/login_screen.dart';
 void main() {
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    registerFirebaseMock();
+    await registerFirebaseMock();
   });
 
   group('LoginScreen', () {

--- a/test/features/booking/chat_booking_test.dart
+++ b/test/features/booking/chat_booking_test.dart
@@ -15,7 +15,7 @@ late MockFirebaseFirestore mockFirestore;
 void main() {
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    registerFirebaseMock();
+    await registerFirebaseMock();
     mockFirestore = MockFirebaseFirestore();
     bookingService = BookingService(firestore: mockFirestore);
   });

--- a/test/features/business/business_dashboard_screen_test.dart
+++ b/test/features/business/business_dashboard_screen_test.dart
@@ -11,7 +11,7 @@ class MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
 void main() {
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    registerFirebaseMock();
+    await registerFirebaseMock();
   });
 
   testWidgets('Business Dashboard shows welcome text',

--- a/test/features/family/family_management_test.dart
+++ b/test/features/family/family_management_test.dart
@@ -140,7 +140,7 @@ class MockFamilyService implements FamilyService {
 void main() {
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    registerFirebaseMock();
+    await registerFirebaseMock();
   });
 
   group('Family Management System Tests', () {

--- a/test/features/family/otp_flow_test.dart
+++ b/test/features/family/otp_flow_test.dart
@@ -13,7 +13,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 void main() {
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    registerFirebaseMock();
+    await registerFirebaseMock();
   });
 
   group('OTP Flow', () {

--- a/test/models/admin_broadcast_message_test.dart
+++ b/test/models/admin_broadcast_message_test.dart
@@ -5,7 +5,7 @@ import '../test_setup.dart';
 void main() {
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    registerFirebaseMock();
+    await registerFirebaseMock();
   });
 
   group('AdminBroadcastMessage Model', () {

--- a/test/models/appointment_test.dart
+++ b/test/models/appointment_test.dart
@@ -7,7 +7,7 @@ import '../test_setup.dart';
 void main() {
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    registerFirebaseMock();
+    await registerFirebaseMock();
   });
 
   group('Appointment Model', () {

--- a/test/models/user_profile_test.dart
+++ b/test/models/user_profile_test.dart
@@ -5,7 +5,7 @@ import '../test_setup.dart';
 void main() {
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    registerFirebaseMock();
+    await registerFirebaseMock();
   });
 
   group('UserProfile Model', () {

--- a/test/otp_flow_test.dart
+++ b/test/otp_flow_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    registerFirebaseMock();
+    await registerFirebaseMock();
   });
 
   testWidgets('OTP flow: send and verify code', (tester) async {

--- a/test/services/admin_service_test.dart
+++ b/test/services/admin_service_test.dart
@@ -7,7 +7,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 void main() {
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    registerFirebaseMock();
+    await registerFirebaseMock();
   });
 
   group('AdminService', () {

--- a/test/services/broadcast_service_test.dart
+++ b/test/services/broadcast_service_test.dart
@@ -10,7 +10,7 @@ class MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
 void main() {
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    registerFirebaseMock();
+    await registerFirebaseMock();
   });
 
   group('BroadcastService', () {

--- a/test/test_setup.dart
+++ b/test/test_setup.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/services.dart';
+import 'package:firebase_core_platform_interface/test.dart';
 
 // Common test utilities
 class TestUtils {
@@ -18,45 +19,8 @@ Future<void> setupTestEnvironment() async {
 }
 
 // Centralized Firebase mock setup for all tests
-void registerFirebaseMock() {
-  const MethodChannel firebaseCoreChannel =
-      MethodChannel('plugins.flutter.io/firebase_core');
-  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-      .setMockMethodCallHandler(
-    firebaseCoreChannel,
-    (MethodCall methodCall) async {
-      print(
-          '[Mock] firebaseCoreChannel: method=[33m[1m[4m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m');
-      print(
-          '[Mock] firebaseCoreChannel: method=[33m[1m[4m[0m[0m[0m[0m[0m[0m[0m');
-      print('[Mock] firebaseCoreChannel: method=[33m');
-      print(
-          '[Mock] firebaseCoreChannel: method=${methodCall.method}, arguments=${methodCall.arguments}');
-      if (methodCall.method == 'Firebase#initializeCore') {
-        return {
-          'app': {
-            'name': '[DEFAULT]',
-            'options': {
-              'apiKey': 'fake',
-              'appId': 'fake',
-              'messagingSenderId': 'fake',
-              'projectId': 'fake',
-            },
-            'pluginConstants': {},
-          },
-          'pluginConstants': {},
-        };
-      }
-      if (methodCall.method == 'Firebase#initializeApp') {
-        return {
-          'name': methodCall.arguments['appName'] ?? '[DEFAULT]',
-          'options': methodCall.arguments['options'] ?? {},
-          'pluginConstants': {},
-        };
-      }
-      return null;
-    },
-  );
+Future<void> registerFirebaseMock() async {
+  setupFirebaseCoreMocks();
   // Add other Firebase channels to mock as needed
 
   // Mock Firebase Auth
@@ -161,60 +125,6 @@ void registerFirebaseMock() {
     return null;
   });
 
-  // Further improved mock for FirebaseCore Pigeon HostApi (required for latest firebase_core)
-  const MethodChannel firebaseCoreHostApiChannel =
-      MethodChannel('dev.flutter.pigeon.FirebaseCoreHostApi');
-  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-      .setMockMethodCallHandler(firebaseCoreHostApiChannel,
-          (MethodCall methodCall) async {
-    print(
-        '[Mock] firebaseCoreHostApiChannel: method=${methodCall.method}, arguments=${methodCall.arguments}');
-    switch (methodCall.method) {
-      case 'initializeCore':
-        return [
-          {
-            'name': '[DEFAULT]',
-            'options': {
-              'apiKey': 'fake',
-              'appId': 'fake',
-              'messagingSenderId': 'fake',
-              'projectId': 'fake',
-            },
-            'pluginConstants': {},
-          }
-        ];
-      case 'initializeApp':
-        return {
-          'name': methodCall.arguments['appName'] ?? '[DEFAULT]',
-          'options': methodCall.arguments['options'] ?? {},
-          'pluginConstants': {},
-        };
-      case 'optionsFromResource':
-        return {
-          'apiKey': 'fake',
-          'appId': 'fake',
-          'messagingSenderId': 'fake',
-          'projectId': 'fake',
-        };
-      case 'getAllApps':
-        return [
-          {
-            'name': '[DEFAULT]',
-            'options': {
-              'apiKey': 'fake',
-              'appId': 'fake',
-              'messagingSenderId': 'fake',
-              'projectId': 'fake',
-            },
-            'pluginConstants': {},
-          }
-        ];
-      case 'deleteApp':
-        return null;
-      default:
-        return null;
-    }
-  });
 
   // Mock file_picker plugin to suppress platform warnings in tests
   const MethodChannel filePickerChannel =
@@ -227,4 +137,5 @@ void registerFirebaseMock() {
     // Return mock responses for file_picker methods as needed
     return null;
   });
+  await Firebase.initializeApp();
 }

--- a/test/whatsapp_share_test.dart
+++ b/test/whatsapp_share_test.dart
@@ -16,7 +16,7 @@ class MockCollectionReference extends Mock
 void main() {
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    registerFirebaseMock();
+    await registerFirebaseMock();
   });
 
   group('WhatsApp Share Service Tests', () {


### PR DESCRIPTION
## Summary
- fix color alpha in admin broadcast screen
- use `setupFirebaseCoreMocks` for Firebase setup in tests
- update tests to await mock initialization

## Testing
- `flutter test --coverage` *(fails: OTP flow test)*

------
https://chatgpt.com/codex/tasks/task_e_6852e2dca3a48324bd60745f00589bb1