### PR TITLE
Refactor tests for non-Flutter CI

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -121,10 +121,10 @@ UI component tests verify the user interface behavior. They test:
 ```dart
 testWidgets('should allow entering email and password', (WidgetTester tester) async {
   await tester.pumpWidget(/* ... */);
-  
+
   final emailField = find.byType(TextField).first;
   await tester.enterText(emailField, 'test@example.com');
-  
+
   expect(find.text('test@example.com'), findsOneWidget);
 });
 ```

--- a/test/booking_service_test.dart
+++ b/test/booking_service_test.dart
@@ -2,20 +2,19 @@ import 'package:appoint/features/booking/services/booking_service.dart';
 import 'package:appoint/models/booking.dart';
 import 'package:flutter_test/flutter_test.dart';
 import './test_setup.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
+import './fake_firebase_firestore.dart';
 
 void main() {
   setUpAll(() async {
-    TestWidgetsFlutterBinding.ensureInitialized();
     await registerFirebaseMock();
   });
 
   group('BookingService', () {
     late BookingService bookingService;
-    late FirebaseFirestore firestore;
+    late FakeFirebaseFirestore firestore;
 
     setUp(() {
-      firestore = FirebaseFirestore.instance;
+      firestore = FakeFirebaseFirestore();
       bookingService = BookingService(firestore: firestore);
     });
 

--- a/test/fake_firebase_firestore.dart
+++ b/test/fake_firebase_firestore.dart
@@ -1,0 +1,32 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class FakeFirebaseFirestore implements FirebaseFirestore {
+  final List<Map<String, dynamic>> addedData = [];
+
+  @override
+  CollectionReference<Map<String, dynamic>> collection(String path) {
+    return _FakeCollectionReference(addedData);
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeCollectionReference implements CollectionReference<Map<String, dynamic>> {
+  final List<Map<String, dynamic>> addedData;
+  _FakeCollectionReference(this.addedData);
+
+  @override
+  Future<DocumentReference<Map<String, dynamic>>> add(Map<String, dynamic> data) async {
+    addedData.add(data);
+    return _FakeDocumentReference();
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeDocumentReference implements DocumentReference<Map<String, dynamic>> {
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/features/admin/admin_broadcast_screen_test.dart
+++ b/test/features/admin/admin_broadcast_screen_test.dart
@@ -16,7 +16,6 @@ late MockFirebaseFirestore mockFirestore;
 void main() {
   return;
   setUpAll(() async {
-    TestWidgetsFlutterBinding.ensureInitialized();
     await registerFirebaseMock();
     mockFirestore = MockFirebaseFirestore();
     broadcastService = BroadcastService(firestore: mockFirestore);

--- a/test/features/admin/admin_role_test.dart
+++ b/test/features/admin/admin_role_test.dart
@@ -12,7 +12,6 @@ late MockFirebaseAuth mockAuth;
 void main() {
   return;
   setUpAll(() async {
-    TestWidgetsFlutterBinding.ensureInitialized();
     await registerFirebaseMock();
     mockAuth = MockFirebaseAuth();
   });

--- a/test/features/auth/login_screen_test.dart
+++ b/test/features/auth/login_screen_test.dart
@@ -6,7 +6,6 @@ import 'package:appoint/features/auth/login_screen.dart';
 
 void main() {
   setUpAll(() async {
-    TestWidgetsFlutterBinding.ensureInitialized();
     await registerFirebaseMock();
   });
 

--- a/test/features/booking/chat_booking_test.dart
+++ b/test/features/booking/chat_booking_test.dart
@@ -14,7 +14,6 @@ late MockFirebaseFirestore mockFirestore;
 
 void main() {
   setUpAll(() async {
-    TestWidgetsFlutterBinding.ensureInitialized();
     await registerFirebaseMock();
     mockFirestore = MockFirebaseFirestore();
     bookingService = BookingService(firestore: mockFirestore);

--- a/test/features/business/business_dashboard_screen_test.dart
+++ b/test/features/business/business_dashboard_screen_test.dart
@@ -10,7 +10,6 @@ class MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
 
 void main() {
   setUpAll(() async {
-    TestWidgetsFlutterBinding.ensureInitialized();
     await registerFirebaseMock();
   });
 

--- a/test/features/family/family_management_test.dart
+++ b/test/features/family/family_management_test.dart
@@ -139,7 +139,6 @@ class MockFamilyService implements FamilyService {
 
 void main() {
   setUpAll(() async {
-    TestWidgetsFlutterBinding.ensureInitialized();
     await registerFirebaseMock();
   });
 

--- a/test/features/family/otp_flow_test.dart
+++ b/test/features/family/otp_flow_test.dart
@@ -12,7 +12,6 @@ import 'package:firebase_auth/firebase_auth.dart';
 
 void main() {
   setUpAll(() async {
-    TestWidgetsFlutterBinding.ensureInitialized();
     await registerFirebaseMock();
   });
 

--- a/test/models/admin_broadcast_message_test.dart
+++ b/test/models/admin_broadcast_message_test.dart
@@ -4,7 +4,6 @@ import '../test_setup.dart';
 
 void main() {
   setUpAll(() async {
-    TestWidgetsFlutterBinding.ensureInitialized();
     await registerFirebaseMock();
   });
 

--- a/test/models/appointment_test.dart
+++ b/test/models/appointment_test.dart
@@ -6,7 +6,6 @@ import '../test_setup.dart';
 
 void main() {
   setUpAll(() async {
-    TestWidgetsFlutterBinding.ensureInitialized();
     await registerFirebaseMock();
   });
 

--- a/test/models/user_profile_test.dart
+++ b/test/models/user_profile_test.dart
@@ -4,7 +4,6 @@ import '../test_setup.dart';
 
 void main() {
   setUpAll(() async {
-    TestWidgetsFlutterBinding.ensureInitialized();
     await registerFirebaseMock();
   });
 

--- a/test/otp_flow_test.dart
+++ b/test/otp_flow_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   setUpAll(() async {
-    TestWidgetsFlutterBinding.ensureInitialized();
     await registerFirebaseMock();
   });
 

--- a/test/services/admin_service_test.dart
+++ b/test/services/admin_service_test.dart
@@ -6,7 +6,6 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 void main() {
   setUpAll(() async {
-    TestWidgetsFlutterBinding.ensureInitialized();
     await registerFirebaseMock();
   });
 

--- a/test/services/broadcast_service_test.dart
+++ b/test/services/broadcast_service_test.dart
@@ -9,7 +9,6 @@ class MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
 
 void main() {
   setUpAll(() async {
-    TestWidgetsFlutterBinding.ensureInitialized();
     await registerFirebaseMock();
   });
 

--- a/test/test_setup.dart
+++ b/test/test_setup.dart
@@ -3,6 +3,8 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/services.dart';
 import 'package:firebase_core_platform_interface/test.dart';
 
+final TestWidgetsFlutterBinding _binding = TestWidgetsFlutterBinding.ensureInitialized();
+
 // Common test utilities
 class TestUtils {
   static const testEmail = 'test@example.com';
@@ -20,6 +22,7 @@ Future<void> setupTestEnvironment() async {
 
 // Centralized Firebase mock setup for all tests
 Future<void> registerFirebaseMock() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
   setupFirebaseCoreMocks();
   // Add other Firebase channels to mock as needed
 

--- a/test/whatsapp_share_test.dart
+++ b/test/whatsapp_share_test.dart
@@ -13,7 +13,6 @@ class MockFirebaseAnalytics extends Mock implements FirebaseAnalytics {}
 
 void main() {
   setUpAll(() async {
-    TestWidgetsFlutterBinding.ensureInitialized();
     await registerFirebaseMock();
   });
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 // Minimal smoke test that does not require Firebase initialization.
 
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
   testWidgets('App smoke test', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(


### PR DESCRIPTION
## Summary
- introduce a fake Firestore for tests
- update BookingService tests to use the fake firestore
- remove `ensureInitialized` calls from individual tests and register globally
- tidy up test setup and README formatting

## Testing
- `dart test --coverage` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_6853be350d0c83249df0bedf31c219f6