### PR TITLE
Fix analyzer warnings and update deprecated APIs

### DIFF
--- a/lib/features/admin/admin_broadcast_screen.dart
+++ b/lib/features/admin/admin_broadcast_screen.dart
@@ -4,6 +4,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'dart:io';
+import '../../utils/color_extensions.dart';
 import '../../models/admin_broadcast_message.dart';
 import '../../services/broadcast_service.dart';
 import '../../providers/admin_provider.dart';
@@ -249,7 +250,7 @@ class _AdminBroadcastScreenState extends ConsumerState<AdminBroadcastScreen> {
 
     return Chip(
       label: Text(text),
-      backgroundColor: color.withOpacity(0.2),
+      backgroundColor: color.withValues(alpha: 0.2),
       labelStyle: TextStyle(color: color),
     );
   }

--- a/lib/features/booking/booking_confirm_screen.dart
+++ b/lib/features/booking/booking_confirm_screen.dart
@@ -27,7 +27,6 @@ class _BookingConfirmScreenState extends ConsumerState<BookingConfirmScreen> {
   bool _syncOutlook = false;
   bool _isLoadingAd = false;
   Appointment? _createdAppointment;
-  late GoogleMapController _mapController;
 
   Future<void> _maybeShowAd() async {
     final isPremium = ref.read(userSubscriptionProvider).maybeWhen(
@@ -69,7 +68,7 @@ class _BookingConfirmScreenState extends ConsumerState<BookingConfirmScreen> {
                   height: 200,
                   child: GoogleMap(
                     initialCameraPosition: MapsService.initialPosition,
-                    onMapCreated: (c) => _mapController = c,
+                    onMapCreated: (_) {},
                     myLocationEnabled: true,
                   ),
                 ),

--- a/lib/features/booking/booking_request_screen.dart
+++ b/lib/features/booking/booking_request_screen.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../models/booking.dart';
-import 'services/booking_service.dart';
-import '../../providers/auth_provider.dart';
 import '../selection/providers/selection_provider.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import '../../services/maps_service.dart';
@@ -18,7 +15,6 @@ class BookingRequestScreen extends ConsumerStatefulWidget {
 }
 
 class _BookingRequestScreenState extends ConsumerState<BookingRequestScreen> {
-  bool _isSubmitting = false;
   late GoogleMapController _mapController;
   final LocationService _locationService = LocationService();
   Set<Marker> _markers = {};
@@ -48,63 +44,12 @@ class _BookingRequestScreenState extends ConsumerState<BookingRequestScreen> {
     }
   }
 
-  Future<void> _submitBooking() async {
-    setState(() => _isSubmitting = true);
-
-    try {
-      final user = ref.read(authProvider).currentUser;
-      final userId = user?.uid ?? '';
-      if (userId.isEmpty) throw Exception('User not logged in');
-
-      final staffId = ref.read(staffSelectionProvider);
-      final serviceId = ref.read(serviceSelectionProvider);
-      final serviceName = ref.read(serviceNameProvider);
-      final dateTime = ref.read(selectedSlotProvider);
-      final duration = ref.read(serviceDurationProvider);
-
-      if (staffId == null ||
-          serviceId == null ||
-          dateTime == null ||
-          duration == null) {
-        throw Exception('Missing required booking information');
-      }
-
-      final booking = Booking(
-        id: '', // Will be set by Firestore
-        userId: userId,
-        staffId: staffId,
-        serviceId: serviceId,
-        serviceName: serviceName ?? 'Unknown Service',
-        dateTime: dateTime,
-        duration: duration,
-        notes: null,
-        createdAt: DateTime.now(),
-      );
-
-      await ref.read(bookingServiceProvider).submitBooking(booking);
-
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Booking confirmed')),
-      );
-      Navigator.pop(context);
-    } catch (e, st) {
-      debugPrint('Error during booking: $e\n$st');
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Failed to confirm booking')),
-      );
-    } finally {
-      if (mounted) setState(() => _isSubmitting = false);
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
-    final staffId = ref.watch(staffSelectionProvider);
-    final serviceId = ref.watch(serviceSelectionProvider);
-    final dateTime = ref.watch(selectedSlotProvider);
-    final duration = ref.watch(serviceDurationProvider);
+    ref.watch(staffSelectionProvider);
+    ref.watch(serviceSelectionProvider);
+    ref.watch(selectedSlotProvider);
+    ref.watch(serviceDurationProvider);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Select Location')),


### PR DESCRIPTION
## Summary
- clean up booking request/confirm screens by removing unused items
- update admin broadcast color handling
- replace a deprecated `withOpacity` call

## Testing
- `flutter analyze`
- `flutter test --coverage --no-pub`
- `flutter build web --no-pub`
- `flutter gen-l10n`


------
https://chatgpt.com/codex/tasks/task_e_68545c88891c8324afd4b5b577449b4e