### PR TITLE
Remove deprecated color API usage

### DIFF
--- a/lib/utils/color_extensions.dart
+++ b/lib/utils/color_extensions.dart
@@ -2,11 +2,11 @@ import 'package:flutter/material.dart';
 
 extension ColorValues on Color {
   Color withValues({double? alpha, double? red, double? green, double? blue}) {
-    final color = this;
-    final a = ((alpha ?? color.alpha) * 255.0).round() & 0xff;
-    final r = ((red ?? color.red) * 255.0).round() & 0xff;
-    final g = ((green ?? color.green) * 255.0).round() & 0xff;
-    final b = ((blue ?? color.blue) * 255.0).round() & 0xff;
+    final argb = value;
+    final a = ((alpha ?? ((argb >> 24) & 0xff) / 255.0) * 255).round() & 0xff;
+    final r = ((red ?? ((argb >> 16) & 0xff) / 255.0) * 255).round() & 0xff;
+    final g = ((green ?? ((argb >> 8) & 0xff) / 255.0) * 255).round() & 0xff;
+    final b = ((blue ?? (argb & 0xff) / 255.0) * 255).round() & 0xff;
 
     return Color.fromARGB(a, r, g, b);
   }


### PR DESCRIPTION
## Summary
- rework ColorValues.withValues implementation
- avoid deprecated color properties

## Testing
- `flutter analyze`
- `flutter test --coverage --no-pub`
- `flutter build web --no-pub`
- `flutter gen-l10n`


------
https://chatgpt.com/codex/tasks/task_e_685461dceb8c83249fe826a5da5aa1df