### PR TITLE
Relax analyzer warnings

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -20,8 +20,10 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+    avoid_unused_constructor_parameters: warning
+    unused_import: warning
+    unused_field: warning
+    deprecated_member_use: warning
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options


### PR DESCRIPTION
## Summary
- degrade lint severity for unused imports, fields, and deprecated APIs

## Testing
- `flutter analyze`
- `flutter test --coverage --no-pub`


------
https://chatgpt.com/codex/tasks/task_e_685480d2409083249231bf7276486205