### PR TITLE
Set warnings only for unused imports

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -25,5 +25,11 @@ linter:
     unused_field: warning
     deprecated_member_use: warning
 
+analyzer:
+  errors:
+    unused_import: warning
+    unused_field: warning
+    deprecated_member_use: warning
+
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options


### PR DESCRIPTION
## Summary
- update `analysis_options.yaml` so `unused_import`, `unused_field`, and
  `deprecated_member_use` only warn

## Testing
- `flutter analyze`
- `flutter test --coverage --no-pub`


------
https://chatgpt.com/codex/tasks/task_e_68548bc5f47c832487a838d6da66b708