### PR TITLE
Fix analyzer issues and add color extensions

### DIFF
--- a/lib/features/admin/admin_broadcast_screen.dart
+++ b/lib/features/admin/admin_broadcast_screen.dart
@@ -4,6 +4,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'dart:io';
+import '../../utils/color_extensions.dart';
 import '../../models/admin_broadcast_message.dart';
 import '../../services/broadcast_service.dart';
 import '../../providers/admin_provider.dart';

--- a/lib/features/playtime/screens/game_list_screen.dart
+++ b/lib/features/playtime/screens/game_list_screen.dart
@@ -6,6 +6,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../providers/playtime_provider.dart';
 import '../../../config/theme.dart';
 import '../../../models/playtime_game.dart';
+import '../../../utils/color_extensions.dart';
 
 class GameListScreen extends ConsumerStatefulWidget {
   const GameListScreen({super.key});

--- a/lib/features/playtime/screens/parent_dashboard_screen.dart
+++ b/lib/features/playtime/screens/parent_dashboard_screen.dart
@@ -7,6 +7,7 @@ import '../../../config/theme.dart';
 import '../../../providers/playtime_provider.dart';
 import '../../../models/playtime_session.dart';
 import '../../../models/playtime_background.dart';
+import '../../../utils/color_extensions.dart';
 
 class ParentDashboardScreen extends ConsumerWidget {
   const ParentDashboardScreen({super.key});

--- a/lib/features/playtime/screens/playtime_landing_screen.dart
+++ b/lib/features/playtime/screens/playtime_landing_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../config/theme.dart';
+import '../../../utils/color_extensions.dart';
 
 class PlaytimeLandingScreen extends ConsumerWidget {
   const PlaytimeLandingScreen({super.key});

--- a/lib/features/playtime/screens/playtime_live_screen.dart
+++ b/lib/features/playtime/screens/playtime_live_screen.dart
@@ -8,6 +8,7 @@ import '../../../config/theme.dart';
 import '../../../providers/playtime_provider.dart';
 import '../../../models/playtime_game.dart';
 import '../../../models/playtime_session.dart';
+import '../../../utils/color_extensions.dart';
 
 class PlaytimeLiveScreen extends ConsumerStatefulWidget {
   final PlaytimeGame? game;

--- a/lib/features/playtime/screens/playtime_virtual_screen.dart
+++ b/lib/features/playtime/screens/playtime_virtual_screen.dart
@@ -8,6 +8,7 @@ import '../../../config/theme.dart';
 import '../../../providers/playtime_provider.dart';
 import '../../../models/playtime_game.dart';
 import '../../../models/playtime_session.dart';
+import '../../../utils/color_extensions.dart';
 
 class PlaytimeVirtualScreen extends ConsumerStatefulWidget {
   final PlaytimeGame? game;

--- a/lib/features/playtime/widgets/custom_background_picker.dart
+++ b/lib/features/playtime/widgets/custom_background_picker.dart
@@ -8,6 +8,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../config/theme.dart';
 import '../../../providers/playtime_provider.dart';
 import '../../../models/playtime_background.dart';
+import '../../../utils/color_extensions.dart';
 
 class CustomBackgroundPicker extends ConsumerStatefulWidget {
   final String? selectedBackgroundId;

--- a/lib/features/studio_business/entry/business_entry_screen.dart
+++ b/lib/features/studio_business/entry/business_entry_screen.dart
@@ -90,7 +90,7 @@ class _NavTile extends StatelessWidget {
       child: Ink(
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(16),
-          color: Theme.of(context).colorScheme.surfaceContainerHighest,
+          color: Theme.of(context).colorScheme.surface,
         ),
         padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
         child: Column(

--- a/lib/utils/color_extensions.dart
+++ b/lib/utils/color_extensions.dart
@@ -1,12 +1,23 @@
 import 'package:flutter/material.dart';
 
 extension ColorValues on Color {
+  /// Returns a copy of this [Color] with the provided channel values replaced.
+  ///
+  /// Each parameter expects a value in the range `0.0`–`1.0`. When a parameter
+  /// is omitted the current channel value is used.
   Color withValues({double? alpha, double? red, double? green, double? blue}) {
-    final a = ((alpha ?? this.a) * 255).round() & 0xff;
-    final r = ((red ?? this.r) * 255).round() & 0xff;
-    final g = ((green ?? this.g) * 255).round() & 0xff;
-    final b = ((blue ?? this.b) * 255).round() & 0xff;
+    int toInt(double value) => (value.clamp(0.0, 1.0) * 255).round();
 
-    return Color.fromARGB(a, r, g, b);
+    return Color.fromARGB(
+      toInt(alpha ?? this.alpha / 255),
+      toInt(red ?? this.red / 255),
+      toInt(green ?? this.green / 255),
+      toInt(blue ?? this.blue / 255),
+    );
   }
+}
+
+extension BuildContextColorTheme on BuildContext {
+  /// Shorthand access to the current [ColorScheme].
+  ColorScheme get colorTheme => Theme.of(this).colorScheme;
 }


### PR DESCRIPTION
## Summary
- fix Color.withValues extension and add BuildContext.colorTheme
- import color extensions where needed
- swap obsolete `surfaceContainerHighest` property

## Testing
- `../flutter_sdk/bin/flutter pub get`
- `../flutter_sdk/bin/flutter pub run build_runner build --delete-conflicting-outputs`
- `../flutter_sdk/bin/flutter analyze`
- `../flutter_sdk/bin/dart test --coverage` *(fails: Could not find package `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6855f7bdf89883248baa0d12c93534a7