### PR TITLE
Fix web auth issues

### DIFF
--- a/lib/core/auth_service.dart
+++ b/lib/core/auth_service.dart
@@ -17,4 +17,11 @@ class AuthService {
   Future<void> signOut() async {
     await _firebaseAuth.signOut();
   }
+
+  /// Sign in using Google identity services popup on web
+  Future<UserCredential> signInWithGooglePopup() async {
+    final googleProvider = GoogleAuthProvider();
+    googleProvider.setCustomParameters({'redirect_uri': redirectUri});
+    return _firebaseAuth.signInWithPopup(googleProvider);
+  }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -5,13 +5,13 @@
   <title>Appoint</title>
   <link rel="manifest" href="manifest.json">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
-  <script src="https://accounts.google.com/gsi/client" async defer></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js" defer></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-analytics.js" defer></script>
 </head>
 <body>
   <script src="flutter.js" defer></script>
   <script src="main.dart.js" type="application/javascript"></script>
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
   <script>
     const firebaseConfig = {
       apiKey: "AIzaSyAEQoB1lR2y6oJQm6Fp19d11i2Y9US8k8",


### PR DESCRIPTION
## Summary
- update web Google sign-in script location
- add signInWithGooglePopup helper

## Testing
- `../flutter_sdk/bin/flutter run -d chrome --web-port=8080` *(fails: Color.withValues undefined)*
- `../flutter_sdk/bin/dart test --coverage=coverage` *(fails: some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68593e2292c08324aa07ba89f8289be4