### PR TITLE
Fix web bootstrap scripts

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="UTF-8">
   <title>Appoint</title>
+  <script src="flutter.js" defer></script>
+  <script src="main.dart.js" type="application/javascript"></script>
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
   <link rel="manifest" href="manifest.json">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js" defer></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-analytics.js" defer></script>
 </head>
 <body>
-  <script src="flutter.js" defer></script>
-  <script src="main.dart.js" type="application/javascript"></script>
-  <script src="https://accounts.google.com/gsi/client" async defer></script>
   <script>
     const firebaseConfig = {
       apiKey: "AIzaSyAEQoB1lR2y6oJQm6Fp19d11i2Y9US8k8",


### PR DESCRIPTION
## Summary
- ensure bootstrap scripts are loaded first in `web/index.html`

## Testing
- `flutter clean`
- `flutter pub get`
- `flutter run -d chrome --web-port=8080` *(fails: method 'withValues' isn't defined for class 'Color')*
- `dart test --coverage=coverage` *(fails to compile animated_icons Offset)*

------
https://chatgpt.com/codex/tasks/task_e_6859424874a483248f73c8d030b5f311