### PR TITLE
Fix web script order

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>Appoint</title>
   <script src="flutter.js" defer></script>
   <script src="main.dart.js" type="application/javascript"></script>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
+  <meta charset="UTF-8">
+  <title>Appoint</title>
   <link rel="manifest" href="manifest.json">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js" defer></script>


### PR DESCRIPTION
## Summary
- move Flutter initialization scripts to top of `index.html`

## Testing
- `flutter analyze` *(fails: packages need newer versions)*
- `dart test --coverage=coverage` *(fails: environment setup issues)*

------
https://chatgpt.com/codex/tasks/task_e_685954c4b91083248b4a4dc592657c11