### PR TITLE
Fix web popup redirect and update auth service

### DIFF
--- a/lib/core/auth_service.dart
+++ b/lib/core/auth_service.dart
@@ -21,7 +21,7 @@ class AuthService {
   /// Sign in using Google identity services popup on web
   Future<UserCredential> signInWithGooglePopup() async {
     final googleProvider = GoogleAuthProvider();
-    googleProvider.setCustomParameters({'redirect_uri': redirectUri});
+    googleProvider.setCustomParameters({'redirectUri': redirectUri});
     return _firebaseAuth.signInWithPopup(googleProvider);
   }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -30,6 +30,7 @@
   <script>
     google.accounts.id.initialize({
       client_id: "944776470711-dj9rkp1ejlj72q64piqspeb056f4fkge.apps.googleusercontent.com",
+      redirect_uri: "http://localhost:8080/__/auth/handler",
     });
     window.addEventListener('load', function(ev) {
       _flutter.loader.load();


### PR DESCRIPTION
## Summary
- include redirect URI when initializing Google Sign-In on the web
- pass redirect URI option in `AuthService.signInWithGooglePopup`

## Testing
- `flutter pub get`
- `dart analyze`
- `flutter test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685956e37610832492f12c9b238789e0