### PR TITLE
Fix firebase config and update environment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,13 @@ metadata.google.internal
 ```bash
 flutter run -d web-server --web-port=8080 --release --no-dds
 flutter run -d chrome --web-port=8080
+flutter analyze
 flutter test --coverage
 firebase emulators:start --only auth,firestore
 ```
+
+If the emulator JAR download fails with a 403 error, manually download the file
+from the Firebase console and place it under `~/.cache/firebase/emulators/`.
 
 
 ## Ambassador Features

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -53,7 +53,7 @@ class DefaultFirebaseOptions {
     apiKey: 'AIzaSyAEQoB1lR2y6oJQm6Fp19d11i2Y9US8k8',
     authDomain: 'app-oint-core.firebaseapp.com',
     projectId: 'app-oint-core',
-    storageBucket: 'app-oint-core.firebasestorage.app',
+    storageBucket: 'app-oint-core.appspot.com',
     messagingSenderId: '944776470711',
     appId: '1:944776470711:web:6f3c833ef110bca6c66d32',
     measurementId: 'G-HHH7T7JFHS',
@@ -64,6 +64,6 @@ class DefaultFirebaseOptions {
     appId: '1:944776470711:android:18eda6eda7b13730c66d32',
     messagingSenderId: '944776470711',
     projectId: 'app-oint-core',
-    storageBucket: 'app-oint-core.firebasestorage.app',
+    storageBucket: 'app-oint-core.appspot.com',
   );
 }

--- a/web/index.html
+++ b/web/index.html
@@ -17,7 +17,7 @@
       apiKey: "AIzaSyAEQoB1lR2y6oJQm6Fp19d11i2Y9US8k8",
       authDomain: "app-oint-core.firebaseapp.com",
       projectId: "app-oint-core",
-      storageBucket: "app-oint-core.firebasestorage.app",
+      storageBucket: "app-oint-core.appspot.com",
       messagingSenderId: "944776470711",
       appId: "1:944776470711:web:6f3c833ef110bca6c66d32",
       measurementId: "G-HHH7T7JFHS"


### PR DESCRIPTION
## Summary
- fix web `index.html` firebase `storageBucket` domain
- update `FirebaseOptions` for storage bucket change
- document emulator JAR fallback and `flutter analyze` in README

## Testing
- `flutter pub get`
- `flutter run -d web-server --web-port=8080 --release --no-dds` *(failed: color extension errors)*
- `flutter run -d chrome --web-port=8080` *(failed: No supported devices found)*
- `dart analyze`
- `dart test --coverage=coverage` *(failed: Offset not found errors)*
- `firebase emulators:start --only auth,firestore` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c81225fc8324869a5b0def6b7b5c