### PR TITLE
Fix SDK constraint and fl_chart version

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -469,10 +469,10 @@ packages:
     dependency: "direct main"
     description:
       name: fl_chart
-      sha256: "00b74ae680df6b1135bdbea00a7d1fc072a9180b7c3f3702e4b19a9943f5ed7d"
+      sha256: "155556c4aba56c8474308d51b4e5446b80a07db9ab66a3cb74aff05c110df982"
       url: "https://pub.dev"
     source: hosted
-    version: "0.66.2"
+    version: "0.60.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
+  sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -42,7 +42,7 @@ dependencies:
   geolocator: ^9.0.2
   flutter_dotenv: ^5.1.0
   mailer: ^6.0.1
-  fl_chart: ^0.66.2
+  fl_chart: ^0.60.0
   go_router: ^13.2.0
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- adjust Dart SDK range
- set fl_chart to ^0.60.0

## Testing
- `flutter clean`
- `flutter pub get`
- `flutter run -d web-server --web-port=8080 --release --no-dds`
- `flutter run -d chrome --web-port=8080` *(fails: No Chrome device)*
- `dart test --coverage=coverage` *(fails: some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6859e5e9412c8324bd056099e8f68ae7