### PR TITLE
Fix network doc & import Offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,19 @@ Appointment scheduling app built with Flutter with advanced features including A
      ```bash
      sudo snap install chromium
      ```  
-   - Verify path:  
+   - Verify path:
      ```bash
      which google-chrome || which chromium-browser
-     ```  
-   - Set `CHROME_EXECUTABLE` in your shell rc:  
+     ```
+   - Set `CHROME_EXECUTABLE` in your shell rc:
      ```bash
      echo 'export CHROME_EXECUTABLE="$(which google-chrome || which chromium-browser)"' >> ~/.zshrc
      source ~/.zshrc
+     ```
+   - Enable Flutter web and fallback to Chromium:
+     ```bash
+     flutter config --enable-web
+     export CHROME_EXECUTABLE="$(which google-chrome || which chromium-browser)"
      ```
 
 2. **Firebase CLI Installation**  
@@ -105,6 +110,12 @@ firebase.googleapis.com
 firebaseinstallations.googleapis.com
 metadata.google.internal
 169.254.169.254
+```
+
+If these domains are blocked, configure pub mirrors:
+```bash
+export PUB_HOSTED_URL="https://pub.flutter-io.cn"
+export FLUTTER_STORAGE_BASE_URL="https://storage.flutter-io.cn"
 ```
 
 4. **Common Testing & Emulators Commands**  

--- a/lib/features/playtime/playtime_hub_screen.dart
+++ b/lib/features/playtime/playtime_hub_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'dart:ui' show Offset;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 

--- a/lib/features/playtime/screens/game_list_screen.dart
+++ b/lib/features/playtime/screens/game_list_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'dart:ui' show Offset;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 

--- a/lib/features/playtime/screens/parent_dashboard_screen.dart
+++ b/lib/features/playtime/screens/parent_dashboard_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'dart:ui' show Offset;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 

--- a/lib/features/playtime/screens/playtime_landing_screen.dart
+++ b/lib/features/playtime/screens/playtime_landing_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'dart:ui' show Offset;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 


### PR DESCRIPTION
## Summary
- note blocked dependencies and mirror variables
- show how to enable Flutter web fallback for Chrome
- import `dart:ui` `Offset` where needed

## Testing
- `flutter pub get` *(fails: domain not in allowlist)*
- `dart test --coverage=coverage` *(fails: Flutter SDK version unknown)*
- `firebase emulators:start --only auth,firestore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ecb01fac8324a76ea91dd6eb6aaa