### PR TITLE
Update SDK constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.18.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
- bump Dart SDK constraint to `'>=3.0.0 <4.0.0'`

## Testing
- `flutter pub get` *(fails: requires SDK >=3.4.0)*
- `dart run build_runner build --delete-conflicting-outputs` *(fails: requires SDK >=3.4.0)*
- `flutter analyze` *(fails: requires SDK >=3.4.0)*

------
https://chatgpt.com/codex/tasks/task_e_685c55f4d7b88324acde682ebf322021