### PR TITLE
Update Dart SDK constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.4.0 <4.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
- adjust the Dart SDK range in `pubspec.yaml`

## Testing
- `flutter pub get` *(fails: Dart SDK 3.3.0 < required 3.4.0)*
- `dart test --coverage` *(fails: could not run without dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685c58c6617883248cd44b0fdd7acced