### PR TITLE
Add full project audit report

### DIFF
--- a/FULL_APP_POINT_AUDIT_REPORT.md
+++ b/FULL_APP_POINT_AUDIT_REPORT.md
@@ -1,0 +1,58 @@
+# Full APP-OINT Project Audit Report
+
+This report summarizes the results of running the commands requested in the audit task. Due to environment limitations, several commands failed. Key findings are categorized by severity and include actionable recommendations.
+
+## 1. Environment & Dependencies
+- `flutter pub get` failed because the project requires Dart `>=3.4.0`, but the provided Flutter SDK uses Dart `3.3.0`.
+- Multiple network requests to `storage.googleapis.com` were blocked, preventing dependency resolution.
+- The current `pubspec.yaml` declares Dart SDK `>=3.4.0 <4.0.0`.
+
+## 2. Code Quality & Static Analysis
+- `flutter analyze` could not run because dependencies were not resolved.
+- Previous analysis log (`flutter_analysis_report.txt`) shows many undefined localization getters and unused imports.
+
+## 3. Build & Code Generation
+- `dart run build_runner build --delete-conflicting-outputs` failed due to the same Dart version mismatch.
+
+## 4. Testing
+- `flutter test --coverage` and `flutter test integration_test/` failed to resolve dependencies and did not execute.
+- Tests reference a custom `FakeFirebaseFirestore`; no references to removed mocks were found.
+
+## 5. Localization
+- ARB files contain numerous `TODO` placeholders (over 8k occurrences).
+- Localization workflow expects each ARB file to have the same key count; the current repo may fail this check due to missing translations.
+
+## 6. Assets & Fonts
+- `pubspec.yaml` declares only one asset: `web/assets/FontManifest.json`, which exists.
+- No fonts are declared.
+
+## 7. Folder Structure & Feature Modules
+- Many feature directories under `lib/features/` lack a `README.md` (e.g., `admin`, `auth`, `business`).
+- No `business_dashboard` or `studio` README found.
+
+## 8. Infrastructure & Stubs
+- TODO comments in `lib/services/playtime_service.dart` indicate stubbed storage integration.
+- No implementations found for Crashlytics, App Check, Dynamic Links, or ML Downloader services.
+
+## 9. CI/CD Config
+- GitHub Actions workflows (`flutter.yml`, `ci.yml`, `localization.yml`) use Flutter `3.3.0`, which is incompatible with the Dart SDK requirement `>=3.4.0`.
+- Localization workflow validates ARB files and generates TODO lists.
+
+## 10. Documentation & Onboarding
+- Root `README.md` provides setup steps but does not mention the Dart SDK requirement or current CI mismatches.
+- Only one additional doc exists under `docs/architecture.md`.
+
+## Severity Summary
+- **Critical**: Dart SDK mismatch prevents dependency resolution, analysis, code generation, and testing.
+- **High**: Missing localization keys (`TODO` placeholders) across all ARB files; many feature directories missing READMEs; CI workflows pinned to older Flutter version.
+- **Medium**: Stubbed services for storage integration and missing implementations for Crashlytics/App Check/Dynamic Links; undefined localization getters reported in analysis logs.
+- **Low**: Minimal assets and fonts; documentation could be expanded.
+
+## Recommendations
+1. Upgrade the Flutter SDK to a version providing Dart `>=3.4.0` to satisfy `pubspec.yaml` constraints.
+2. Ensure network access to `storage.googleapis.com` for package retrieval or configure mirrors.
+3. Resolve localization placeholders and update ARB files so the localization workflow passes.
+4. Add README.md files for each feature module describing screens, providers, and tests.
+5. Implement missing services (Storage, Crashlytics, App Check, Dynamic Links, ML Downloader) or remove stubs.
+6. Update CI workflows to use the correct Flutter/Dart version and run tests/analysis successfully.
+7. Expand documentation with onboarding instructions and details about feature scaffolding and CI steps.


### PR DESCRIPTION
## Summary
- add a markdown report summarizing analysis of the APP-OINT repo

## Testing
- `flutter pub get` *(fails: Dart SDK version solving failed)*
- `flutter analyze` *(fails: version solving failed)*
- `dart run build_runner build --delete-conflicting-outputs` *(fails: version solving failed)*
- `flutter test --coverage` *(fails: version solving failed)*
- `flutter test integration_test/` *(fails: version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_685c5cb345a48324906f8fa42cb1b883