### PR TITLE
Fix workflows network restrictions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,9 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    network:
-      allowed-hosts: |
-        storage.googleapis.com
-        pub.dev
+    env:
+      PUB_HOSTED_URL: https://pub.dev
+      FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
     services:
       firebase:
         image: cdrx/fake-firebase-emulator:latest
@@ -21,8 +20,6 @@ jobs:
           - 5001:5001   # Functions
       env:
         FIREBASE_PROJECT: app-oint-core
-        PUB_HOSTED_URL: https://pub.dev
-        FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
     steps:
       - uses: actions/checkout@v4
 
@@ -57,12 +54,8 @@ jobs:
   deploy-functions:
     needs: build-and-test
     runs-on: ubuntu-latest
-    network:
-      allowed-hosts: |
-        storage.googleapis.com
-        pub.dev
     if: github.ref == 'refs/heads/main'
-    
+
     env:
       PUB_HOSTED_URL: https://pub.dev
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
@@ -97,12 +90,8 @@ jobs:
   deploy-hosting:
     needs: build-and-test
     runs-on: ubuntu-latest
-    network:
-      allowed-hosts: |
-        storage.googleapis.com
-        pub.dev
     if: github.ref == 'refs/heads/main'
-    
+
     env:
       PUB_HOSTED_URL: https://pub.dev
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
@@ -132,12 +121,8 @@ jobs:
   smoke-test:
     needs: [deploy-functions, deploy-hosting]
     runs-on: ubuntu-latest
-    network:
-      allowed-hosts: |
-        storage.googleapis.com
-        pub.dev
     if: github.ref == 'refs/heads/main'
-    
+
     env:
       PUB_HOSTED_URL: https://pub.dev
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
@@ -165,12 +150,8 @@ jobs:
 
   security-scan:
     runs-on: ubuntu-latest
-    network:
-      allowed-hosts: |
-        storage.googleapis.com
-        pub.dev
     if: github.ref == 'refs/heads/main'
-    
+
     env:
       PUB_HOSTED_URL: https://pub.dev
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
@@ -189,12 +170,8 @@ jobs:
   notify:
     needs: [build-and-test, deploy-functions, deploy-hosting, smoke-test]
     runs-on: ubuntu-latest
-    network:
-      allowed-hosts: |
-        storage.googleapis.com
-        pub.dev
     if: always()
-    
+
     env:
       PUB_HOSTED_URL: https://pub.dev
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -10,10 +10,6 @@ jobs:
     analyze_and_test:
       name: Analyze & Test
       runs-on: ubuntu-latest
-      network:
-        allowed-hosts: |
-          storage.googleapis.com
-          pub.dev
       env:
         PUB_HOSTED_URL: https://pub.dev
         FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com

--- a/.github/workflows/flutter_web.yml
+++ b/.github/workflows/flutter_web.yml
@@ -9,10 +9,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    network:
-      allowed-hosts: |
-        storage.googleapis.com
-        pub.dev
     env:
       PUB_HOSTED_URL: https://pub.dev
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -10,10 +10,6 @@ jobs:
   localization_validation:
     name: Localization Validation
     runs-on: ubuntu-latest
-    network:
-      allowed-hosts: |
-        storage.googleapis.com
-        pub.dev
     env:
       PUB_HOSTED_URL: https://pub.dev
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com


### PR DESCRIPTION
## Summary
- remove `allowed-hosts` from all CI workflows
- keep environment variables for pub and Flutter storage

## Testing
- `dart test --coverage` *(fails: The current Dart SDK version is 3.3.0; appoint requires >=3.4.0 <4.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_685cf8cb4b508324b64dbbd44f1415c1