### PR TITLE
Update CI workflows for Flutter 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,30 +24,31 @@ jobs:
         FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
     steps:
       - uses: actions/checkout@v4
-
-        - name: Setup Flutter
-          uses: subosito/flutter-action@v2
-          with:
-            flutter-version: "3.7.0"
-            channel: stable
-
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.7.0'
+          channel: stable
+      - name: Verify Flutter Version
+        run: flutter --version
       - name: Install dependencies
         run: flutter pub get
-
+      - name: Build runner
+        run: dart run build_runner build --delete-conflicting-outputs
+      - name: Flutter analyze
+        run: flutter analyze
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
-
       - name: Start Firebase emulators
         run: |
           firebase emulators:start --only firestore,functions &
           echo $! > emulator.pid
-
-      - name: Run unit tests
-        run: flutter test test/services
-
-      - name: Run integration tests
-        run: flutter test integration_test/app_test.dart
-
+      - name: Flutter tests
+        run: flutter test --coverage
+      - name: Flutter integration tests
+        run: flutter test integration_test/
+      - name: Flutter build web
+        run: flutter build web
       - name: Stop emulators
         if: always()
         run: |
@@ -101,22 +102,27 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Setup Flutter
+      - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.7.0"
+          flutter-version: '3.7.0'
           channel: stable
-
+      - name: Verify Flutter Version
+        run: flutter --version
       - name: Install dependencies
         run: flutter pub get
-
+      - name: Build runner
+        run: dart run build_runner build --delete-conflicting-outputs
+      - name: Flutter analyze
+        run: flutter analyze
+      - name: Flutter tests
+        run: flutter test --coverage
+      - name: Flutter integration tests
+        run: flutter test integration_test/
       - name: Build Web App
         run: flutter build web --release
-
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
-
       - name: Deploy to Firebase Hosting
         run: firebase deploy --only hosting --token "${{ secrets.FIREBASE_TOKEN }}"
 
@@ -132,16 +138,25 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Setup Flutter
+      - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.7.0"
+          flutter-version: '3.7.0'
           channel: stable
-
+      - name: Verify Flutter Version
+        run: flutter --version
       - name: Install dependencies
         run: flutter pub get
-
+      - name: Build runner
+        run: dart run build_runner build --delete-conflicting-outputs
+      - name: Flutter analyze
+        run: flutter analyze
+      - name: Flutter tests
+        run: flutter test --coverage
+      - name: Flutter integration tests
+        run: flutter test integration_test/
+      - name: Flutter build web
+        run: flutter build web
       - name: Run Smoke Tests
         run: |
           echo "Running smoke tests against production..."
@@ -161,7 +176,24 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.7.0'
+      - name: Verify Flutter Version
+        run: flutter --version
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Build runner
+        run: dart run build_runner build --delete-conflicting-outputs
+      - name: Flutter analyze
+        run: flutter analyze
+      - name: Flutter tests
+        run: flutter test --coverage
+      - name: Flutter integration tests
+        run: flutter test integration_test/
+      - name: Flutter build web
+        run: flutter build web
       - name: Run Security Scan
         run: |
           echo "Running security scan..."
@@ -179,6 +211,25 @@ jobs:
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
 
     steps:
+      - uses: actions/checkout@v4
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.7.0'
+      - name: Verify Flutter Version
+        run: flutter --version
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Build runner
+        run: dart run build_runner build --delete-conflicting-outputs
+      - name: Flutter analyze
+        run: flutter analyze
+      - name: Flutter tests
+        run: flutter test --coverage
+      - name: Flutter integration tests
+        run: flutter test integration_test/
+      - name: Flutter build web
+        run: flutter build web
       - name: Notify on Success
         if: success()
         run: |
@@ -190,4 +241,4 @@ jobs:
         if: failure()
         run: |
           echo "❌ CI/CD pipeline failed!"
-          echo "Please check the logs for details." 
+          echo "Please check the logs for details."

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -14,18 +14,20 @@ jobs:
         PUB_HOSTED_URL: https://pub.dev
         FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       steps:
-      - uses: actions/checkout@v3
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: "3.7.0"
-
-      - run: flutter pub get
-      - run: dart run build_runner build --delete-conflicting-outputs
-      - run: flutter analyze
-      - run: flutter test --coverage
-      - run: flutter build web
-      - uses: codecov/codecov-action@v3
-        with:
-          files: coverage/lcov.info
-          fail_ci_if_error: true
+        - uses: actions/checkout@v3
+        - name: Set up Flutter
+          uses: subosito/flutter-action@v2
+          with:
+            flutter-version: '3.7.0'
+        - name: Verify Flutter Version
+          run: flutter --version
+        - run: flutter pub get
+        - run: dart run build_runner build --delete-conflicting-outputs
+        - run: flutter analyze
+        - run: flutter test --coverage
+        - run: flutter test integration_test/
+        - run: flutter build web
+        - uses: codecov/codecov-action@v3
+          with:
+            files: coverage/lcov.info
+            fail_ci_if_error: true

--- a/.github/workflows/flutter_web.yml
+++ b/.github/workflows/flutter_web.yml
@@ -19,8 +19,10 @@ jobs:
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
       with:
-        flutter-version: "3.7.0"
+        flutter-version: '3.7.0'
         channel: 'stable'
+    - name: Verify Flutter Version
+      run: flutter --version
     
     - name: Install dependencies
       run: flutter pub get
@@ -36,6 +38,8 @@ jobs:
     
     - name: Run tests
       run: flutter test --coverage
+    - name: Run integration tests
+      run: flutter test integration_test/
     
     - name: Build web
       run: flutter build web --release

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -19,7 +19,9 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.7.0"
+          flutter-version: '3.7.0'
+      - name: Verify Flutter Version
+        run: flutter --version
       
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -32,6 +34,16 @@ jobs:
       
       - name: Get Flutter dependencies
         run: flutter pub get
+      - name: Build runner
+        run: dart run build_runner build --delete-conflicting-outputs
+      - name: Flutter analyze
+        run: flutter analyze
+      - name: Flutter tests
+        run: flutter test --coverage
+      - name: Flutter integration tests
+        run: flutter test integration_test/
+      - name: Flutter build web
+        run: flutter build web
       
       - name: Validate ARB files structure
         run: |


### PR DESCRIPTION
## Summary
- set up Flutter 3.7.0 at the start of every workflow
- verify the Flutter version as a debug step
- run a consistent Flutter workflow in CI jobs

## Testing
- `dart pub get` *(fails: domain storage.googleapis.com blocked)*
- `dart test --coverage` *(fails: domain storage.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685cfdfcc3d883249aac1d1fa407cde8