### PR TITLE
Add CI network access docs and pre-flight check

### DIFF
--- a/.github/ISSUE_TEMPLATE/ci-network-access.md
+++ b/.github/ISSUE_TEMPLATE/ci-network-access.md
@@ -1,0 +1,13 @@
+---
+name: CI Network Access Issue
+about: Report blocked network access in CI for pub.dev or storage.googleapis.com
+title: "[CI] Network Access Blocked for {{host}}"
+labels: ci
+---
+
+**Host:** `{{host}}`
+**Error:** Describe the network allowlist error seen in CI logs.
+**Environment:** (e.g., GitHub Enterprise or self-hosted runner)
+**Steps to reproduce:**
+1. Trigger CI job
+2. Observe failure on `curl` pre-flight check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,14 @@ jobs:
         with:
           flutter-version: '3.7.0'
           channel: stable
+      - name: Pre-flight: Verify network access
+        run: |
+          for host in pub.dev storage.googleapis.com; do
+            curl --head --fail https://$host || {
+              echo "❌ Cannot reach $host. Ensure it’s whitelisted in CI network settings."
+              exit 1
+            }
+          done
       - name: Verify Flutter Version
         run: flutter --version
       - name: Install dependencies
@@ -107,6 +115,14 @@ jobs:
         with:
           flutter-version: '3.7.0'
           channel: stable
+      - name: Pre-flight: Verify network access
+        run: |
+          for host in pub.dev storage.googleapis.com; do
+            curl --head --fail https://$host || {
+              echo "❌ Cannot reach $host. Ensure it’s whitelisted in CI network settings."
+              exit 1
+            }
+          done
       - name: Verify Flutter Version
         run: flutter --version
       - name: Install dependencies
@@ -143,6 +159,14 @@ jobs:
         with:
           flutter-version: '3.7.0'
           channel: stable
+      - name: Pre-flight: Verify network access
+        run: |
+          for host in pub.dev storage.googleapis.com; do
+            curl --head --fail https://$host || {
+              echo "❌ Cannot reach $host. Ensure it’s whitelisted in CI network settings."
+              exit 1
+            }
+          done
       - name: Verify Flutter Version
         run: flutter --version
       - name: Install dependencies
@@ -180,6 +204,14 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.7.0'
+      - name: Pre-flight: Verify network access
+        run: |
+          for host in pub.dev storage.googleapis.com; do
+            curl --head --fail https://$host || {
+              echo "❌ Cannot reach $host. Ensure it’s whitelisted in CI network settings."
+              exit 1
+            }
+          done
       - name: Verify Flutter Version
         run: flutter --version
       - name: Install dependencies
@@ -216,6 +248,14 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.7.0'
+      - name: Pre-flight: Verify network access
+        run: |
+          for host in pub.dev storage.googleapis.com; do
+            curl --head --fail https://$host || {
+              echo "❌ Cannot reach $host. Ensure it’s whitelisted in CI network settings."
+              exit 1
+            }
+          done
       - name: Verify Flutter Version
         run: flutter --version
       - name: Install dependencies

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -19,6 +19,14 @@ jobs:
           uses: subosito/flutter-action@v2
           with:
             flutter-version: '3.7.0'
+        - name: Pre-flight: Verify network access
+          run: |
+            for host in pub.dev storage.googleapis.com; do
+              curl --head --fail https://$host || {
+                echo "❌ Cannot reach $host. Ensure it’s whitelisted in CI network settings."
+                exit 1
+              }
+            done
         - name: Verify Flutter Version
           run: flutter --version
         - run: flutter pub get

--- a/.github/workflows/flutter_web.yml
+++ b/.github/workflows/flutter_web.yml
@@ -21,6 +21,14 @@ jobs:
       with:
         flutter-version: '3.7.0'
         channel: 'stable'
+    - name: Pre-flight: Verify network access
+      run: |
+        for host in pub.dev storage.googleapis.com; do
+          curl --head --fail https://$host || {
+            echo "❌ Cannot reach $host. Ensure it’s whitelisted in CI network settings."
+            exit 1
+          }
+        done
     - name: Verify Flutter Version
       run: flutter --version
     

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -20,6 +20,14 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.7.0'
+      - name: Pre-flight: Verify network access
+        run: |
+          for host in pub.dev storage.googleapis.com; do
+            curl --head --fail https://$host || {
+              echo "❌ Cannot reach $host. Ensure it’s whitelisted in CI network settings."
+              exit 1
+            }
+          done
       - name: Verify Flutter Version
         run: flutter --version
       

--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ Appointment scheduling app built with Flutter with advanced features including A
    flutter run
 ```
 
+## CI Network Access Requirements
+
+The CI environment must allow outbound HTTPS to:
+- `storage.googleapis.com`
+- `pub.dev`
+
+### GitHub Actions (Enterprise)
+Go to **Settings → Actions → General**, and under "Network access," add those domains to the allowlist.
+
+### Self-Hosted Runners
+Update your firewall/proxy settings on the runner machines to permit connections to the above hosts.
+
+Without these, `flutter pub get`, `dart run build_runner`, and `flutter test` will fail.
+
 
 ## Environment Setup & Testing
 


### PR DESCRIPTION
## Summary
- document required network access for CI in README
- check connectivity to pub.dev and storage.googleapis.com in all workflows
- add issue template for CI network errors

## Testing
- `dart test --coverage` *(fails: dart command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d00f076e88324b2d7aa5261e23d70