### PR TITLE
Enable offline pub in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       PUB_HOSTED_URL: https://pub.dev
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
+      FLUTTER_CACHE_DIR: ~/.flutter
     services:
       firebase:
         image: cdrx/fake-firebase-emulator:latest
@@ -24,6 +25,21 @@ jobs:
         FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
     steps:
       - uses: actions/checkout@v4
+      - name: Cache Pub packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Cache Flutter SDK artifacts
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.FLUTTER_CACHE_DIR }}
+          key: ${{ runner.os }}-flutter-${{ hashFiles('.github/workflows/**.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-flutter-
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -45,10 +61,10 @@ jobs:
           done
       - name: Verify Flutter Version
         run: flutter --version
-      - name: Install dependencies
-        run: dart pub get
-      - name: Build runner
-        run: dart run build_runner build --delete-conflicting-outputs
+      - name: Install dependencies offline
+        run: flutter pub get --offline
+      - name: Run code generation offline
+        run: dart run build_runner build --delete-conflicting-outputs --offline
       - name: Dart analyze
         run: dart analyze
       - name: Set up Node.js
@@ -64,7 +80,7 @@ jobs:
       - name: Flutter tests
         run: dart test --coverage
       - name: Integration tests
-        run: dart test integration_test/
+        run: flutter test integration_test/
       - name: Flutter build web
         run: flutter build web
       - name: Stop emulators
@@ -76,14 +92,30 @@ jobs:
     needs: build-and-test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
-    
+
     env:
       PUB_HOSTED_URL: https://pub.dev
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
+      FLUTTER_CACHE_DIR: ~/.flutter
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Cache Pub packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Cache Flutter SDK artifacts
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.FLUTTER_CACHE_DIR }}
+          key: ${{ runner.os }}-flutter-${{ hashFiles('.github/workflows/**.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-flutter-
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -110,14 +142,30 @@ jobs:
     needs: build-and-test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
-    
+
     env:
       PUB_HOSTED_URL: https://pub.dev
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
+      FLUTTER_CACHE_DIR: ~/.flutter
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Cache Pub packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Cache Flutter SDK artifacts
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.FLUTTER_CACHE_DIR }}
+          key: ${{ runner.os }}-flutter-${{ hashFiles('.github/workflows/**.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-flutter-
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -139,10 +187,10 @@ jobs:
           done
       - name: Verify Flutter Version
         run: flutter --version
-      - name: Install dependencies
-        run: dart pub get
-      - name: Build runner
-        run: dart run build_runner build --delete-conflicting-outputs
+      - name: Install dependencies offline
+        run: flutter pub get --offline
+      - name: Run code generation offline
+        run: dart run build_runner build --delete-conflicting-outputs --offline
       - name: Dart analyze
         run: dart analyze
       - name: Set up Node.js
@@ -152,7 +200,7 @@ jobs:
       - name: Flutter tests
         run: dart test --coverage
       - name: Integration tests
-        run: dart test integration_test/
+        run: flutter test integration_test/
       - name: Build Web App
         run: flutter build web --release
       - name: Install Firebase CLI
@@ -164,14 +212,30 @@ jobs:
     needs: [deploy-functions, deploy-hosting]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
-    
+
     env:
       PUB_HOSTED_URL: https://pub.dev
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
+      FLUTTER_CACHE_DIR: ~/.flutter
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Cache Pub packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Cache Flutter SDK artifacts
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.FLUTTER_CACHE_DIR }}
+          key: ${{ runner.os }}-flutter-${{ hashFiles('.github/workflows/**.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-flutter-
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -193,16 +257,16 @@ jobs:
           done
       - name: Verify Flutter Version
         run: flutter --version
-      - name: Install dependencies
-        run: dart pub get
-      - name: Build runner
-        run: dart run build_runner build --delete-conflicting-outputs
+      - name: Install dependencies offline
+        run: flutter pub get --offline
+      - name: Run code generation offline
+        run: dart run build_runner build --delete-conflicting-outputs --offline
       - name: Dart analyze
         run: dart analyze
       - name: Flutter tests
         run: dart test --coverage
       - name: Integration tests
-        run: dart test integration_test/
+        run: flutter test integration_test/
       - name: Flutter build web
         run: flutter build web
       - name: Run Smoke Tests
@@ -216,14 +280,30 @@ jobs:
   security-scan:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
-    
+
     env:
       PUB_HOSTED_URL: https://pub.dev
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
+      FLUTTER_CACHE_DIR: ~/.flutter
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Cache Pub packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Cache Flutter SDK artifacts
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.FLUTTER_CACHE_DIR }}
+          key: ${{ runner.os }}-flutter-${{ hashFiles('.github/workflows/**.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-flutter-
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -244,16 +324,16 @@ jobs:
           done
       - name: Verify Flutter Version
         run: flutter --version
-      - name: Install dependencies
-        run: dart pub get
-      - name: Build runner
-        run: dart run build_runner build --delete-conflicting-outputs
+      - name: Install dependencies offline
+        run: flutter pub get --offline
+      - name: Run code generation offline
+        run: dart run build_runner build --delete-conflicting-outputs --offline
       - name: Dart analyze
         run: dart analyze
       - name: Flutter tests
         run: dart test --coverage
       - name: Integration tests
-        run: dart test integration_test/
+        run: flutter test integration_test/
       - name: Flutter build web
         run: flutter build web
       - name: Run Security Scan
@@ -267,13 +347,29 @@ jobs:
     needs: [build-and-test, deploy-functions, deploy-hosting, smoke-test]
     runs-on: ubuntu-latest
     if: always()
-    
+
     env:
       PUB_HOSTED_URL: https://pub.dev
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
+      FLUTTER_CACHE_DIR: ~/.flutter
 
     steps:
       - uses: actions/checkout@v4
+      - name: Cache Pub packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Cache Flutter SDK artifacts
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.FLUTTER_CACHE_DIR }}
+          key: ${{ runner.os }}-flutter-${{ hashFiles('.github/workflows/**.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-flutter-
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -294,16 +390,16 @@ jobs:
           done
       - name: Verify Flutter Version
         run: flutter --version
-      - name: Install dependencies
-        run: dart pub get
-      - name: Build runner
-        run: dart run build_runner build --delete-conflicting-outputs
+      - name: Install dependencies offline
+        run: flutter pub get --offline
+      - name: Run code generation offline
+        run: dart run build_runner build --delete-conflicting-outputs --offline
       - name: Dart analyze
         run: dart analyze
       - name: Flutter tests
         run: dart test --coverage
       - name: Integration tests
-        run: dart test integration_test/
+        run: flutter test integration_test/
       - name: Flutter build web
         run: flutter build web
       - name: Notify on Success

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -13,8 +13,24 @@ jobs:
       env:
         PUB_HOSTED_URL: https://pub.dev
         FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
+        FLUTTER_CACHE_DIR: ~/.flutter
       steps:
         - uses: actions/checkout@v3
+        - name: Cache Pub packages
+          uses: actions/cache@v3
+          with:
+            path: ~/.pub-cache
+            key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.yaml') }}
+            restore-keys: |
+              ${{ runner.os }}-pub-
+
+        - name: Cache Flutter SDK artifacts
+          uses: actions/cache@v3
+          with:
+            path: ${{ env.FLUTTER_CACHE_DIR }}
+            key: ${{ runner.os }}-flutter-${{ hashFiles('.github/workflows/**.yml') }}
+            restore-keys: |
+              ${{ runner.os }}-flutter-
         - name: Set up Flutter
           uses: subosito/flutter-action@v2
           with:
@@ -35,11 +51,13 @@ jobs:
             done
         - name: Verify Flutter Version
           run: flutter --version
-        - run: dart pub get
-        - run: dart run build_runner build --delete-conflicting-outputs
+        - name: Install dependencies offline
+          run: flutter pub get --offline
+        - name: Run code generation offline
+          run: dart run build_runner build --delete-conflicting-outputs --offline
         - run: dart analyze
         - run: dart test --coverage
-        - run: dart test integration_test/
+        - run: flutter test integration_test/
         - run: flutter build web
         - uses: codecov/codecov-action@v3
           with:

--- a/.github/workflows/flutter_web.yml
+++ b/.github/workflows/flutter_web.yml
@@ -12,10 +12,26 @@ jobs:
     env:
       PUB_HOSTED_URL: https://pub.dev
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
+      FLUTTER_CACHE_DIR: ~/.flutter
 
     steps:
     - uses: actions/checkout@v3
-    
+    - name: Cache Pub packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.pub-cache
+        key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pub-
+
+    - name: Cache Flutter SDK artifacts
+      uses: actions/cache@v3
+      with:
+        path: ${{ env.FLUTTER_CACHE_DIR }}
+        key: ${{ runner.os }}-flutter-${{ hashFiles('.github/workflows/**.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-flutter-
+
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
       with:
@@ -38,11 +54,11 @@ jobs:
     - name: Verify Flutter Version
       run: flutter --version
     
-    - name: Install dependencies
-      run: dart pub get
+    - name: Install dependencies offline
+      run: flutter pub get --offline
 
-    - name: Build runner
-      run: dart run build_runner build --delete-conflicting-outputs
+    - name: Run code generation offline
+      run: dart run build_runner build --delete-conflicting-outputs --offline
     
     - name: Verify formatting
       run: dart format --output=none --set-exit-if-changed .
@@ -53,7 +69,7 @@ jobs:
     - name: Run tests
       run: dart test --coverage
     - name: Run integration tests
-      run: dart test integration_test/
+      run: flutter test integration_test/
     
     - name: Build web
       run: flutter build web --release

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -13,9 +13,25 @@ jobs:
     env:
       PUB_HOSTED_URL: https://pub.dev
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
+      FLUTTER_CACHE_DIR: ~/.flutter
     steps:
       - uses: actions/checkout@v3
-      
+      - name: Cache Pub packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Cache Flutter SDK artifacts
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.FLUTTER_CACHE_DIR }}
+          key: ${{ runner.os }}-flutter-${{ hashFiles('.github/workflows/**.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-flutter-
+
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -46,16 +62,16 @@ jobs:
       - name: Install cspell
         run: npm install -g cspell
       
-      - name: Get Flutter dependencies
-        run: dart pub get
-      - name: Build runner
-        run: dart run build_runner build --delete-conflicting-outputs
+      - name: Install dependencies offline
+        run: flutter pub get --offline
+      - name: Run code generation offline
+        run: dart run build_runner build --delete-conflicting-outputs --offline
       - name: Dart analyze
         run: dart analyze
       - name: Flutter tests
         run: dart test --coverage
       - name: Integration tests
-        run: dart test integration_test/
+        run: flutter test integration_test/
       - name: Flutter build web
         run: flutter build web
       


### PR DESCRIPTION
## Summary
- cache Flutter packages and artifacts in all workflows
- run `flutter pub get` and code generation in offline mode
- run integration tests with `flutter test`

## Testing
- `dart test --coverage` *(fails: Dart SDK 3.3.0 < 3.4.0)*

------
https://chatgpt.com/codex/tasks/task_e_685d0bb98580832498889a0b27db215a