### PR TITLE
Fix Dart SDK and offline Flutter setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,9 @@ jobs:
           PUB_HOSTED_URL: https://pub.dev
           FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
     steps:
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.7.0'
       - uses: actions/checkout@v4
+      - name: Use bundled Flutter SDK
+        run: echo "${{ github.workspace }}/flutter_sdk/bin" >> $GITHUB_PATH
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:
@@ -78,11 +76,9 @@ jobs:
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.7.0'
       - uses: actions/checkout@v4
+      - name: Use bundled Flutter SDK
+        run: echo "${{ github.workspace }}/flutter_sdk/bin" >> $GITHUB_PATH
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:
@@ -122,11 +118,9 @@ jobs:
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.7.0'
       - uses: actions/checkout@v4
+      - name: Use bundled Flutter SDK
+        run: echo "${{ github.workspace }}/flutter_sdk/bin" >> $GITHUB_PATH
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:
@@ -172,11 +166,9 @@ jobs:
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.7.0'
       - uses: actions/checkout@v4
+      - name: Use bundled Flutter SDK
+        run: echo "${{ github.workspace }}/flutter_sdk/bin" >> $GITHUB_PATH
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:
@@ -217,11 +209,9 @@ jobs:
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.7.0'
       - uses: actions/checkout@v4
+      - name: Use bundled Flutter SDK
+        run: echo "${{ github.workspace }}/flutter_sdk/bin" >> $GITHUB_PATH
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:
@@ -262,11 +252,9 @@ jobs:
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.7.0'
       - uses: actions/checkout@v4
+      - name: Use bundled Flutter SDK
+        run: echo "${{ github.workspace }}/flutter_sdk/bin" >> $GITHUB_PATH
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -15,11 +15,9 @@ jobs:
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.7.0'
       - uses: actions/checkout@v3
+      - name: Use bundled Flutter SDK
+        run: echo "${{ github.workspace }}/flutter_sdk/bin" >> $GITHUB_PATH
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:
@@ -33,6 +31,11 @@ jobs:
         run: flutter --version
       - name: Verify Dart Version
         run: dart --version
+      - name: "Pre-flight: Verify network access"
+        run: |
+          for host in pub.dev storage.googleapis.com; do
+            curl --head --fail https://$host || { echo "❌ Cannot reach $host"; exit 1; }
+          done
       - run: flutter pub get
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs

--- a/.github/workflows/flutter_web.yml
+++ b/.github/workflows/flutter_web.yml
@@ -15,11 +15,9 @@ jobs:
       FLUTTER_CACHE_DIR: ~/.flutter
 
     steps:
-    - name: Set up Flutter
-      uses: subosito/flutter-action@v2
-      with:
-        flutter-version: '3.7.0'
     - uses: actions/checkout@v3
+    - name: Use bundled Flutter SDK
+      run: echo "${{ github.workspace }}/flutter_sdk/bin" >> $GITHUB_PATH
     - name: Cache Pub packages
       uses: actions/cache@v3
       with:
@@ -33,6 +31,11 @@ jobs:
       run: flutter --version
     - name: Verify Dart Version
       run: dart --version
+    - name: "Pre-flight: Verify network access"
+      run: |
+        for host in pub.dev storage.googleapis.com; do
+          curl --head --fail https://$host || { echo "❌ Cannot reach $host"; exit 1; }
+        done
     - run: flutter pub get
     - run: dart pub get
     - run: dart run build_runner build --delete-conflicting-outputs

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -15,11 +15,9 @@ jobs:
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.7.0'
       - uses: actions/checkout@v3
+      - name: Use bundled Flutter SDK
+        run: echo "${{ github.workspace }}/flutter_sdk/bin" >> $GITHUB_PATH
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:
@@ -33,6 +31,11 @@ jobs:
         run: flutter --version
       - name: Verify Dart Version
         run: dart --version
+      - name: "Pre-flight: Verify network access"
+        run: |
+          for host in pub.dev storage.googleapis.com; do
+            curl --head --fail https://$host || { echo "❌ Cannot reach $host"; exit 1; }
+          done
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.4.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
   flutter:
@@ -21,7 +21,7 @@ dependencies:
   cloud_functions: ^4.7.5
   firebase_analytics: ^10.4.0
   firebase_storage: ^11.5.1
-  firebase_crashlytics: ^4.6.0
+  firebase_crashlytics: ^4.3.7
   flutter_stripe: ^11.5.0
   flutter_riverpod: ^2.5.1
   freezed_annotation: ^2.4.4


### PR DESCRIPTION
## Summary
- relax Dart SDK constraint to Dart 3.3
- use bundled Flutter SDK in workflows
- verify connectivity to pub.dev and storage in workflows
- pin firebase_crashlytics to valid version

## Testing
- `../flutter_sdk/bin/flutter --version`
- `../flutter_sdk/bin/flutter pub get` *(failed: domain is not in allowlist)*
- `../flutter_sdk/bin/flutter analyze` *(failed: domain is not in allowlist)*
- `../flutter_sdk/bin/dart test --coverage` *(failed: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_685ea73b132c83249c761cdf43a5ba44