### PR TITLE
Fix Firebase mock setup in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       - run: dart run build_runner build --delete-conflicting-outputs
       - run: flutter analyze
       - run: dart analyze
+      - run: flutter test --coverage
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
@@ -60,6 +61,7 @@ jobs:
         run: |
           firebase emulators:start --only firestore,functions &
           echo $! > emulator.pid
+      - run: flutter test --coverage
       - run: dart test --coverage
       - run: dart test integration_test/
       - run: flutter build web
@@ -192,6 +194,7 @@ jobs:
       - run: dart run build_runner build --delete-conflicting-outputs
       - run: flutter analyze
       - run: dart analyze
+      - run: flutter test --coverage
       - run: dart test --coverage
       - run: dart test integration_test/
       - run: flutter build web
@@ -235,6 +238,7 @@ jobs:
       - run: dart run build_runner build --delete-conflicting-outputs
       - run: flutter analyze
       - run: dart analyze
+      - run: flutter test --coverage
       - run: dart test --coverage
       - run: dart test integration_test/
       - run: flutter build web
@@ -278,6 +282,7 @@ jobs:
       - run: dart run build_runner build --delete-conflicting-outputs
       - run: flutter analyze
       - run: dart analyze
+      - run: flutter test --coverage
       - run: dart test --coverage
       - run: dart test integration_test/
       - run: flutter build web

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -41,6 +41,7 @@ jobs:
       - run: dart run build_runner build --delete-conflicting-outputs
       - run: flutter analyze
       - run: dart analyze
+      - run: flutter test --coverage
       - run: dart test --coverage
       - run: dart test integration_test/
       - run: flutter build web

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -1,7 +1,9 @@
 import 'package:integration_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
+import '../test/fake_firebase_setup.dart';
 
-void main() {
+Future<void> main() async {
+  await initializeTestFirebase();
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   test('sample test', () async {

--- a/test/ambassador_dashboard_test.dart
+++ b/test/ambassador_dashboard_test.dart
@@ -1,4 +1,3 @@
-@Skip('Firebase not initialized')
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -8,14 +7,13 @@ import 'package:appoint/features/ambassador_dashboard_screen.dart';
 import 'package:appoint/providers/ambassador_data_provider.dart';
 import 'package:appoint/services/ambassador_service.dart';
 import 'package:appoint/models/ambassador_stats.dart';
-import 'test_setup.dart';
+import 'fake_firebase_setup.dart';
 
 class MockAmbassadorService extends Mock implements AmbassadorService {}
 
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
   setUpAll(() async {
-    await setupTestEnvironment();
+    await initializeTestFirebase();
   });
 
   late MockAmbassadorService mockService;

--- a/test/ambassador_quota_service_test.dart
+++ b/test/ambassador_quota_service_test.dart
@@ -1,11 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/services/ambassador_quota_service.dart';
-import 'test_setup.dart';
+import 'fake_firebase_setup.dart';
 
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
   setUpAll(() async {
-    await setupTestEnvironment();
+    await initializeTestFirebase();
   });
 
   group('AmbassadorQuotaService Tests', () {

--- a/test/booking_service_test.dart
+++ b/test/booking_service_test.dart
@@ -1,14 +1,13 @@
-@Skip('Pending Firebase setup conflicts')
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:appoint/features/booking/services/booking_service.dart';
 import 'package:appoint/models/booking.dart';
-import './test_setup.dart';
+import './fake_firebase_setup.dart';
 import './fake_firebase_firestore.dart';
 
 void main() {
   setUpAll(() async {
-    await registerFirebaseMock();
+    await initializeTestFirebase();
   });
 
   group('BookingService', () {

--- a/test/fake_firebase_setup.dart
+++ b/test/fake_firebase_setup.dart
@@ -1,0 +1,120 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/services.dart';
+import 'package:firebase_core_platform_interface/test.dart';
+
+/// Initializes a fake [FirebaseApp] and mocks common Firebase method channels
+/// so that widget and integration tests can run without real backends.
+Future<FirebaseApp> initializeTestFirebase() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setupFirebaseCoreMocks();
+
+  // Mock Firebase Auth
+  const MethodChannel firebaseAuthChannel =
+      MethodChannel('plugins.flutter.io/firebase_auth');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(firebaseAuthChannel,
+          (MethodCall methodCall) async {
+    switch (methodCall.method) {
+      case 'signInWithEmailAndPassword':
+        return {
+          'user': {
+            'uid': 'test-user',
+            'email': 'test@example.com',
+          },
+        };
+      case 'signOut':
+        return null;
+      case 'currentUser':
+        return {
+          'uid': 'test-user',
+          'email': 'test@example.com',
+        };
+      default:
+        return null;
+    }
+  });
+
+  // Mock Cloud Firestore
+  const MethodChannel cloudFirestoreChannel =
+      MethodChannel('plugins.flutter.io/cloud_firestore');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(cloudFirestoreChannel,
+          (MethodCall methodCall) async {
+    switch (methodCall.method) {
+      case 'DocumentReference#get':
+        return {'data': {}};
+      case 'DocumentReference#set':
+        return null;
+      case 'DocumentReference#update':
+        return null;
+      case 'DocumentReference#delete':
+        return null;
+      case 'Query#get':
+        return {'documents': []};
+      case 'Query#count':
+        return {'count': 0};
+      default:
+        return null;
+    }
+  });
+
+  // Mock Firebase Storage
+  const MethodChannel firebaseStorageChannel =
+      MethodChannel('plugins.flutter.io/firebase_storage');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(firebaseStorageChannel,
+          (MethodCall methodCall) async {
+    return null;
+  });
+
+  // Mock Firebase Messaging
+  const MethodChannel firebaseMessagingChannel =
+      MethodChannel('plugins.flutter.io/firebase_messaging');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(firebaseMessagingChannel,
+          (MethodCall methodCall) async {
+    return null;
+  });
+
+  // Mock Firebase App Check
+  const MethodChannel firebaseAppCheckChannel =
+      MethodChannel('plugins.flutter.io/firebase_app_check');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(firebaseAppCheckChannel,
+          (MethodCall methodCall) async {
+    return null;
+  });
+
+  // Mock Firebase Crashlytics
+  const MethodChannel firebaseCrashlyticsChannel =
+      MethodChannel('plugins.flutter.io/firebase_crashlytics');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(firebaseCrashlyticsChannel,
+          (MethodCall methodCall) async {
+    return null;
+  });
+
+  // Mock file_picker plugin to suppress platform warnings in tests
+  const MethodChannel filePickerChannel =
+      MethodChannel('plugins.flutter.io/file_picker');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(filePickerChannel,
+          (MethodCall methodCall) async {
+    return null;
+  });
+
+  const firebaseOptions = FirebaseOptions(
+    apiKey: 'test-api-key',
+    appId: '1:1234567890:android:1234567890abcdef',
+    messagingSenderId: '1234567890',
+    projectId: 'test-project',
+  );
+
+  try {
+    return await Firebase.initializeApp(name: 'TEST', options: firebaseOptions);
+  } catch (_) {
+    return Firebase.app('TEST');
+  }
+}
+

--- a/test/features/admin/admin_broadcast_screen_test.dart
+++ b/test/features/admin/admin_broadcast_screen_test.dart
@@ -1,9 +1,8 @@
-@Skip('Pending Firebase setup conflicts')
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../test_setup.dart';
+import '../../fake_firebase_setup.dart';
 import 'package:appoint/features/admin/admin_broadcast_screen.dart';
 import 'package:appoint/l10n/app_localizations.dart';
 import 'package:mockito/mockito.dart';
@@ -17,7 +16,7 @@ late MockFirebaseFirestore mockFirestore;
 
 void main() {
   setUpAll(() async {
-    await registerFirebaseMock();
+    await initializeTestFirebase();
     mockFirestore = MockFirebaseFirestore();
     broadcastService = BroadcastService(firestore: mockFirestore);
     // Stub FirebaseAnalytics if used

--- a/test/features/admin/admin_panel_integration_test.dart
+++ b/test/features/admin/admin_panel_integration_test.dart
@@ -1,4 +1,3 @@
-@Skip('Firebase not initialized')
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -15,7 +14,7 @@ import 'package:appoint/services/admin_service.dart';
 import 'package:appoint/models/admin_dashboard_stats.dart';
 import 'package:appoint/models/admin_broadcast_message.dart';
 import 'package:appoint/l10n/app_localizations.dart';
-import '../../test_setup.dart';
+import '../../fake_firebase_setup.dart';
 
 // Generate mocks
 @GenerateMocks([AdminService, FirebaseAuth, FirebaseFirestore])
@@ -23,7 +22,7 @@ import 'admin_panel_integration_test.mocks.dart';
 
 void main() {
   setUpAll(() async {
-    await setupTestEnvironment();
+    await initializeTestFirebase();
   });
 
   group('Admin Panel Integration Tests', () {

--- a/test/features/admin/admin_role_test.dart
+++ b/test/features/admin/admin_role_test.dart
@@ -1,8 +1,7 @@
-@Skip('Pending Firebase setup conflicts')
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:appoint/providers/admin_provider.dart';
-import '../../test_setup.dart';
+import '../../fake_firebase_setup.dart';
 import 'package:mockito/mockito.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
@@ -12,7 +11,7 @@ late MockFirebaseAuth mockAuth;
 
 void main() {
   setUpAll(() async {
-    await registerFirebaseMock();
+    await initializeTestFirebase();
     mockAuth = MockFirebaseAuth();
   });
 

--- a/test/features/auth/login_screen_test.dart
+++ b/test/features/auth/login_screen_test.dart
@@ -1,13 +1,12 @@
-@Skip('Pending Firebase setup conflicts')
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../test_setup.dart';
+import '../../fake_firebase_setup.dart';
 import 'package:appoint/features/auth/login_screen.dart';
 
 void main() {
   setUpAll(() async {
-    await registerFirebaseMock();
+    await initializeTestFirebase();
   });
 
   group('LoginScreen', () {

--- a/test/features/booking/chat_booking_test.dart
+++ b/test/features/booking/chat_booking_test.dart
@@ -1,8 +1,7 @@
-@Skip('Pending Firebase setup conflicts')
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import '../../test_setup.dart';
+import '../../fake_firebase_setup.dart';
 import 'package:appoint/features/booking/screens/chat_booking_screen.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -15,7 +14,7 @@ late MockFirebaseFirestore mockFirestore;
 
 void main() {
   setUpAll(() async {
-    await registerFirebaseMock();
+    await initializeTestFirebase();
     mockFirestore = MockFirebaseFirestore();
     bookingService = BookingService(firestore: mockFirestore);
   });

--- a/test/features/business/business_dashboard_screen_test.dart
+++ b/test/features/business/business_dashboard_screen_test.dart
@@ -1,10 +1,9 @@
-@Skip('Pending Firebase setup conflicts')
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:appoint/features/business/screens/business_dashboard_screen.dart';
-import '../../test_setup.dart';
+import '../../fake_firebase_setup.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
@@ -12,7 +11,7 @@ class MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
 
 void main() {
   setUpAll(() async {
-    await registerFirebaseMock();
+    await initializeTestFirebase();
   });
 
   testWidgets('Business Dashboard shows welcome text',

--- a/test/features/family/family_management_test.dart
+++ b/test/features/family/family_management_test.dart
@@ -1,4 +1,3 @@
-@Skip('Pending Firebase setup conflicts')
 import 'package:flutter_test/flutter_test.dart';
 
 // ignore_for_file: unused_local_variable, undefined_identifier
@@ -10,7 +9,7 @@ import 'package:appoint/services/family_service.dart';
 import 'package:appoint/providers/family_provider.dart';
 import 'package:appoint/providers/auth_provider.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import '../../test_setup.dart';
+import '../../fake_firebase_setup.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
@@ -142,7 +141,7 @@ class MockFamilyService implements FamilyService {
 
 void main() {
   setUpAll(() async {
-    await registerFirebaseMock();
+    await initializeTestFirebase();
   });
 
   group('Family Management System Tests', () {

--- a/test/features/family/otp_flow_test.dart
+++ b/test/features/family/otp_flow_test.dart
@@ -1,9 +1,8 @@
-@Skip('Pending Firebase setup conflicts')
 import 'package:flutter_test/flutter_test.dart';
 
 // ignore_for_file: unused_local_variable, undefined_identifier, definitely_unassigned_late_local_variable
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../test_setup.dart';
+import '../../fake_firebase_setup.dart';
 import 'package:appoint/services/family_service.dart';
 import 'package:appoint/providers/otp_provider.dart';
 import 'package:appoint/providers/family_provider.dart';
@@ -13,7 +12,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 
 void main() {
   setUpAll(() async {
-    await registerFirebaseMock();
+    await initializeTestFirebase();
   });
 
   group('OTP Flow', () {

--- a/test/features/studio_business/business_profile_screen_test.dart
+++ b/test/features/studio_business/business_profile_screen_test.dart
@@ -1,10 +1,13 @@
-@Skip('Firebase not initialized')
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:appoint/features/studio_business/screens/business_profile_screen.dart';
+import '../../fake_firebase_setup.dart';
 
 void main() {
+  setUpAll(() async {
+    await initializeTestFirebase();
+  });
   group('BusinessProfileScreen', () {
     testWidgets('renders correctly', (WidgetTester tester) async {
       await tester.pumpWidget(

--- a/test/models/admin_broadcast_message_test.dart
+++ b/test/models/admin_broadcast_message_test.dart
@@ -1,11 +1,10 @@
-@Skip('Pending Firebase setup conflicts')
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/models/admin_broadcast_message.dart';
-import '../test_setup.dart';
+import '../fake_firebase_setup.dart';
 
 void main() {
   setUpAll(() async {
-    await registerFirebaseMock();
+    await initializeTestFirebase();
   });
 
   group('AdminBroadcastMessage Model', () {

--- a/test/models/appointment_test.dart
+++ b/test/models/appointment_test.dart
@@ -1,13 +1,12 @@
-@Skip('Pending Firebase setup conflicts')
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/models/appointment.dart';
 import 'package:appoint/models/contact.dart';
 import 'package:appoint/models/invite.dart';
-import '../test_setup.dart';
+import '../fake_firebase_setup.dart';
 
 void main() {
   setUpAll(() async {
-    await registerFirebaseMock();
+    await initializeTestFirebase();
   });
 
   group('Appointment Model', () {

--- a/test/models/user_profile_test.dart
+++ b/test/models/user_profile_test.dart
@@ -1,11 +1,10 @@
-@Skip('Pending Firebase setup conflicts')
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/models/user_profile.dart';
-import '../test_setup.dart';
+import '../fake_firebase_setup.dart';
 
 void main() {
   setUpAll(() async {
-    await registerFirebaseMock();
+    await initializeTestFirebase();
   });
 
   group('UserProfile Model', () {

--- a/test/otp_flow_test.dart
+++ b/test/otp_flow_test.dart
@@ -1,14 +1,13 @@
-@Skip('Pending Firebase setup conflicts')
 import 'package:flutter_test/flutter_test.dart';
 
 // Replace with the real file & widget name for your app's entrypoint
-import './test_setup.dart';
+import './fake_firebase_setup.dart';
 
 // Flutter widgets & material controls
 
 void main() {
   setUpAll(() async {
-    await registerFirebaseMock();
+    await initializeTestFirebase();
   });
 
   testWidgets('OTP flow: send and verify code', (tester) async {}, skip: true);

--- a/test/playtime/playtime_provider_test.dart
+++ b/test/playtime/playtime_provider_test.dart
@@ -1,18 +1,16 @@
-@Skip('Firebase not initialized')
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:firebase_core/firebase_core.dart';
 
 import '../../lib/providers/playtime_provider.dart';
 import '../../lib/models/playtime_game.dart';
 import '../../lib/models/playtime_session.dart';
 import '../../lib/models/playtime_background.dart';
 import '../../lib/services/playtime_service.dart';
+import '../fake_firebase_setup.dart';
 
 void main() {
   setUpAll(() async {
-    TestWidgetsFlutterBinding.ensureInitialized();
-    await Firebase.initializeApp();
+    await initializeTestFirebase();
   });
 
   group('Playtime Provider Tests', () {

--- a/test/services/admin_service_test.dart
+++ b/test/services/admin_service_test.dart
@@ -1,14 +1,12 @@
-@Skip('Pending Firebase setup conflicts')
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/services/admin_service.dart';
-import '../test_setup.dart';
+import '../fake_firebase_setup.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 void main() {
   setUpAll(() async {
-    await registerFirebaseMock();
+    await initializeTestFirebase();
   });
 
   group('AdminService', () {

--- a/test/services/broadcast_service_test.dart
+++ b/test/services/broadcast_service_test.dart
@@ -1,9 +1,7 @@
-@Skip('Pending Firebase setup conflicts')
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/services/broadcast_service.dart';
 import 'package:appoint/models/admin_broadcast_message.dart';
-import '../test_setup.dart';
+import '../fake_firebase_setup.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
@@ -11,7 +9,7 @@ class MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
 
 void main() {
   setUpAll(() async {
-    await registerFirebaseMock();
+    await initializeTestFirebase();
   });
 
   group('BroadcastService', () {

--- a/test/whatsapp_share_test.dart
+++ b/test/whatsapp_share_test.dart
@@ -1,9 +1,7 @@
-@Skip('Pending Firebase setup conflicts')
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/services/whatsapp_share_service.dart';
 import 'package:appoint/models/smart_share_link.dart';
-import './test_setup.dart';
+import './fake_firebase_setup.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
@@ -15,7 +13,7 @@ class MockFirebaseAnalytics extends Mock implements FirebaseAnalytics {}
 
 void main() {
   setUpAll(() async {
-    await registerFirebaseMock();
+    await initializeTestFirebase();
   });
 
   group('WhatsApp Share Service Tests', () {


### PR DESCRIPTION
## Summary
- add `fake_firebase_setup.dart` for in-memory Firebase
- use mock setup in widget/service tests and remove skip flags
- run `flutter test --coverage` in workflows

## Testing
- `flutter test --coverage` *(fails: syncfusion_flutter_charts requires newer Dart SDK)*

------
https://chatgpt.com/codex/tasks/task_e_685eb279907c8324a7c907a76e8d7c32