### PR TITLE
Implement personal scaffolds

### DIFF
--- a/lib/auth_wrapper.dart
+++ b/lib/auth_wrapper.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class AuthWrapper extends StatelessWidget {
+  const AuthWrapper({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final isLoggedIn = false; // TODO: replace with real auth check
+    if (isLoggedIn) {
+      Navigator.pushNamed(context, '/home');
+    } else {
+      Navigator.pushNamed(context, '/login');
+    }
+    // spec §3.1
+    return const SizedBox.shrink();
+  }
+}

--- a/lib/features/personal_app/home_feed_screen.dart
+++ b/lib/features/personal_app/home_feed_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class HomeFeedScreen extends StatelessWidget {
+  const HomeFeedScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: implement per spec §2.1
+    return const Scaffold(
+      body: Center(child: Text('Home Feed Screen')),
+    );
+  }
+}

--- a/lib/features/personal_app/login_screen.dart
+++ b/lib/features/personal_app/login_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class LoginScreen extends StatelessWidget {
+  const LoginScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: implement per spec §2.1
+    return const Scaffold(
+      body: Center(child: Text('Login Screen')),
+    );
+  }
+}

--- a/lib/features/personal_app/onboarding_screen.dart
+++ b/lib/features/personal_app/onboarding_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class OnboardingScreen extends StatelessWidget {
+  const OnboardingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: implement per spec §2.1
+    return const Scaffold(
+      body: Center(child: Text('Onboarding Screen')),
+    );
+  }
+}

--- a/lib/features/scheduler/scheduler_screen.dart
+++ b/lib/features/scheduler/scheduler_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class SchedulerScreen extends StatelessWidget {
+  const SchedulerScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: implement per spec §2.1
+    return const Scaffold(
+      body: Center(child: Text('Scheduler Screen')),
+    );
+  }
+}

--- a/lib/features/studio/application/service.dart
+++ b/lib/features/studio/application/service.dart
@@ -1,1 +1,1 @@
-class StudioService {}
+class StudioService { /* TODO: implement per spec §4.2 */ }

--- a/lib/features/studio/domain/models.dart
+++ b/lib/features/studio/domain/models.dart
@@ -1,1 +1,1 @@
-class StudioBooking {}
+class StudioModel { /* TODO: implement per spec §4.2 */ }


### PR DESCRIPTION
## Summary
- scaffold personal app login, onboarding, and home feed screens
- add scheduler screen stub
- update studio placeholders
- add simple auth wrapper routing example

## Testing
- `../flutter_sdk/bin/flutter analyze --no-pub`
- `../flutter_sdk/bin/flutter test --coverage` *(fails: some tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_685ec2d9b904832498d1a783cd78f2bb