### PR TITLE
Fix offline pub and pre-flight check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,16 +38,19 @@ jobs:
         run: flutter clean
       - name: Verify Flutter Version
         run: flutter --version
-      - name: Verify Dart Version
-        run: dart --version
-      - name: "Pre-flight: Verify network access"
+      - name: Pre-flight: Verify network access & Dart
         run: |
+          dart --version
           for host in pub.dev storage.googleapis.com; do
-            curl --head --fail https://$host || { echo "❌ Cannot reach $host"; exit 1; }
+            curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
       - run: flutter pub get
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs
+      - name: Set PUB_CACHE for offline
+        run: echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
+      - name: Fetch dependencies offline
+        run: flutter pub get --offline
       - run: flutter analyze
       - run: dart analyze
       - run: flutter test --coverage
@@ -92,8 +95,12 @@ jobs:
         run: flutter clean
       - name: Verify Flutter Version
         run: flutter --version
-      - name: Verify Dart Version
-        run: dart --version
+      - name: Pre-flight: Verify network access & Dart
+        run: |
+          dart --version
+          for host in pub.dev storage.googleapis.com; do
+            curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
+          done
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
@@ -134,16 +141,19 @@ jobs:
         run: flutter clean
       - name: Verify Flutter Version
         run: flutter --version
-      - name: Verify Dart Version
-        run: dart --version
-      - name: "Pre-flight: Verify network access"
+      - name: Pre-flight: Verify network access & Dart
         run: |
+          dart --version
           for host in pub.dev storage.googleapis.com; do
-            curl --head --fail https://$host || { echo "❌ Cannot reach $host"; exit 1; }
+            curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
       - run: flutter pub get
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs
+      - name: Set PUB_CACHE for offline
+        run: echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
+      - name: Fetch dependencies offline
+        run: flutter pub get --offline
       - run: flutter analyze
       - run: dart analyze
       - name: Set up Node.js
@@ -182,16 +192,19 @@ jobs:
         run: flutter clean
       - name: Verify Flutter Version
         run: flutter --version
-      - name: Verify Dart Version
-        run: dart --version
-      - name: "Pre-flight: Verify network access"
+      - name: Pre-flight: Verify network access & Dart
         run: |
+          dart --version
           for host in pub.dev storage.googleapis.com; do
-            curl --head --fail https://$host || { echo "❌ Cannot reach $host"; exit 1; }
+            curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
       - run: flutter pub get
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs
+      - name: Set PUB_CACHE for offline
+        run: echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
+      - name: Fetch dependencies offline
+        run: flutter pub get --offline
       - run: flutter analyze
       - run: dart analyze
       - run: flutter test --coverage
@@ -226,16 +239,19 @@ jobs:
         run: flutter clean
       - name: Verify Flutter Version
         run: flutter --version
-      - name: Verify Dart Version
-        run: dart --version
-      - name: "Pre-flight: Verify network access"
+      - name: Pre-flight: Verify network access & Dart
         run: |
+          dart --version
           for host in pub.dev storage.googleapis.com; do
-            curl --head --fail https://$host || { echo "❌ Cannot reach $host"; exit 1; }
+            curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
       - run: flutter pub get
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs
+      - name: Set PUB_CACHE for offline
+        run: echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
+      - name: Fetch dependencies offline
+        run: flutter pub get --offline
       - run: flutter analyze
       - run: dart analyze
       - run: flutter test --coverage
@@ -270,16 +286,19 @@ jobs:
         run: flutter clean
       - name: Verify Flutter Version
         run: flutter --version
-      - name: Verify Dart Version
-        run: dart --version
-      - name: "Pre-flight: Verify network access"
+      - name: Pre-flight: Verify network access & Dart
         run: |
+          dart --version
           for host in pub.dev storage.googleapis.com; do
-            curl --head --fail https://$host || { echo "❌ Cannot reach $host"; exit 1; }
+            curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
       - run: flutter pub get
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs
+      - name: Set PUB_CACHE for offline
+        run: echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
+      - name: Fetch dependencies offline
+        run: flutter pub get --offline
       - run: flutter analyze
       - run: dart analyze
       - run: flutter test --coverage


### PR DESCRIPTION
## Summary
- consolidate Dart version & network checks
- pre-populate PUB_CACHE and run `flutter pub get --offline`
- enable offline before analyze and test steps

## Testing
- `flutter analyze`
- `dart analyze`
- `flutter test --coverage` *(fails: some tests failed)*
- `dart test --coverage=coverage` *(fails: test loading errors)*
- `flutter build web` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685edd4070e483248e7016a348e7a409