### PR TITLE
Stabilize widget tests

### DIFF
--- a/test/ambassador_dashboard_test.dart
+++ b/test/ambassador_dashboard_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:appoint/features/ambassador_dashboard_screen.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:appoint/providers/ambassador_data_provider.dart';
 import 'package:appoint/services/ambassador_service.dart';
 import 'package:appoint/models/ambassador_stats.dart';
@@ -11,10 +12,9 @@ import 'fake_firebase_setup.dart';
 
 class MockAmbassadorService extends Mock implements AmbassadorService {}
 
-void main() {
-  setUpAll(() async {
-    await initializeTestFirebase();
-  });
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
 
   late MockAmbassadorService mockService;
   late ProviderContainer container;

--- a/test/ambassador_quota_service_test.dart
+++ b/test/ambassador_quota_service_test.dart
@@ -1,11 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/services/ambassador_quota_service.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'fake_firebase_setup.dart';
 
-void main() {
-  setUpAll(() async {
-    await initializeTestFirebase();
-  });
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
 
   group('AmbassadorQuotaService Tests', () {
     late AmbassadorQuotaService service;

--- a/test/booking_service_test.dart
+++ b/test/booking_service_test.dart
@@ -2,13 +2,13 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:appoint/features/booking/services/booking_service.dart';
 import 'package:appoint/models/booking.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import './fake_firebase_setup.dart';
 import './fake_firebase_firestore.dart';
 
-void main() {
-  setUpAll(() async {
-    await initializeTestFirebase();
-  });
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
 
   group('BookingService', () {
     late BookingService bookingService;

--- a/test/family_integration_test.dart
+++ b/test/family_integration_test.dart
@@ -1,7 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/models/family_link.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
+import 'fake_firebase_setup.dart';
 
-void main() {
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
   group('Family Integration Tests', () {
     test('FamilyLink model should serialize correctly', () {
       final link = FamilyLink(

--- a/test/features/admin/admin_broadcast_screen_test.dart
+++ b/test/features/admin/admin_broadcast_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../fake_firebase_setup.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:appoint/features/admin/admin_broadcast_screen.dart';
 import 'package:appoint/l10n/app_localizations.dart';
 import 'package:mockito/mockito.dart';
@@ -14,14 +15,13 @@ class MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
 late BroadcastService broadcastService;
 late MockFirebaseFirestore mockFirestore;
 
-void main() {
-  setUpAll(() async {
-    await initializeTestFirebase();
-    mockFirestore = MockFirebaseFirestore();
-    broadcastService = BroadcastService(firestore: mockFirestore);
-    // Stub FirebaseAnalytics if used
-    // when(FirebaseAnalytics.instance).thenReturn(MockFirebaseAnalytics());
-  });
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+  mockFirestore = MockFirebaseFirestore();
+  broadcastService = BroadcastService(firestore: mockFirestore);
+  // Stub FirebaseAnalytics if used
+  // when(FirebaseAnalytics.instance).thenReturn(MockFirebaseAnalytics());
 
   group('AdminBroadcastScreen', () {
     Widget createTestWidget(Widget child) {

--- a/test/features/admin/admin_broadcast_test.dart
+++ b/test/features/admin/admin_broadcast_test.dart
@@ -1,7 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/models/admin_broadcast_message.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
+import '../../fake_firebase_setup.dart';
 
-void main() {
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
   group('Admin Broadcast System Tests', () {
     group('BroadcastMessage Model Tests', () {
       test('should create broadcast message with all required fields', () {

--- a/test/features/admin/admin_demo_screens_test.dart
+++ b/test/features/admin/admin_demo_screens_test.dart
@@ -6,8 +6,12 @@ import 'package:appoint/features/admin/admin_monetization_control_demo_screen.da
 import 'package:appoint/features/admin/admin_broadcast_system_demo_screen.dart';
 import 'package:appoint/features/admin/admin_error_logs_demo_screen.dart';
 import 'package:appoint/features/admin/admin_demo_panel_screen.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
+import '../../fake_firebase_setup.dart';
 
-void main() {
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
   group('Admin Demo Screens Tests', () {
     testWidgets('MonetizationControlDemoScreen can be instantiated',
         (WidgetTester tester) async {

--- a/test/features/admin/admin_panel_audit_test.dart
+++ b/test/features/admin/admin_panel_audit_test.dart
@@ -6,8 +6,12 @@ import 'package:appoint/features/admin/admin_demo_panel_screen.dart';
 import 'package:appoint/features/admin/admin_monetization_control_demo_screen.dart';
 import 'package:appoint/features/admin/admin_broadcast_system_demo_screen.dart';
 import 'package:appoint/features/admin/admin_error_logs_demo_screen.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
+import '../../fake_firebase_setup.dart';
 
-void main() {
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
   group('Admin Panel System Audit', () {
     testWidgets('Admin Demo Panel renders all navigation tiles correctly',
         (tester) async {

--- a/test/features/admin/admin_panel_integration_test.dart
+++ b/test/features/admin/admin_panel_integration_test.dart
@@ -15,15 +15,15 @@ import 'package:appoint/models/admin_dashboard_stats.dart';
 import 'package:appoint/models/admin_broadcast_message.dart';
 import 'package:appoint/l10n/app_localizations.dart';
 import '../../fake_firebase_setup.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 
 // Generate mocks
 @GenerateMocks([AdminService, FirebaseAuth, FirebaseFirestore])
 import 'admin_panel_integration_test.mocks.dart';
 
-void main() {
-  setUpAll(() async {
-    await initializeTestFirebase();
-  });
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
 
 group('Admin Panel Integration Tests', () {
     late MockAdminService mockAdminService;

--- a/test/features/admin/admin_role_test.dart
+++ b/test/features/admin/admin_role_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:appoint/providers/admin_provider.dart';
 import '../../fake_firebase_setup.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:mockito/mockito.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
@@ -9,11 +10,10 @@ class MockFirebaseAuth extends Mock implements FirebaseAuth {}
 
 late MockFirebaseAuth mockAuth;
 
-void main() {
-  setUpAll(() async {
-    await initializeTestFirebase();
-    mockAuth = MockFirebaseAuth();
-  });
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+  mockAuth = MockFirebaseAuth();
 
   group('Admin Role Tests', () {
     test('isAdminProvider should return false when user is not authenticated',

--- a/test/features/ambassador/ambassador_dashboard_test.dart
+++ b/test/features/ambassador/ambassador_dashboard_test.dart
@@ -1,8 +1,12 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../../lib/models/ambassador_stats.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
+import '../../fake_firebase_setup.dart';
 
-void main() {
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
   group('Ambassador Dashboard Logic Tests', () {
     test('filters chart data based on country filter', () {
       final data = AmbassadorData(

--- a/test/features/auth/login_screen_test.dart
+++ b/test/features/auth/login_screen_test.dart
@@ -2,12 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../fake_firebase_setup.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:appoint/features/auth/login_screen.dart';
 
-void main() {
-  setUpAll(() async {
-    await initializeTestFirebase();
-  });
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
 
   group('LoginScreen', () {
     testWidgets('should display the title in app bar',

--- a/test/features/booking/chat_booking_test.dart
+++ b/test/features/booking/chat_booking_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import '../../fake_firebase_setup.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:appoint/features/booking/screens/chat_booking_screen.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -12,12 +13,11 @@ class MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
 late BookingService bookingService;
 late MockFirebaseFirestore mockFirestore;
 
-void main() {
-  setUpAll(() async {
-    await initializeTestFirebase();
-    mockFirestore = MockFirebaseFirestore();
-    bookingService = BookingService(firestore: mockFirestore);
-  });
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+  mockFirestore = MockFirebaseFirestore();
+  bookingService = BookingService(firestore: mockFirestore);
 
   group('ChatBookingScreen', () {
     testWidgets('should display chat interface', (WidgetTester tester) async {

--- a/test/features/business/business_dashboard_screen_test.dart
+++ b/test/features/business/business_dashboard_screen_test.dart
@@ -4,15 +4,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:appoint/features/business/screens/business_dashboard_screen.dart';
 import '../../fake_firebase_setup.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
 
-void main() {
-  setUpAll(() async {
-    await initializeTestFirebase();
-  });
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
 
   testWidgets('Business Dashboard shows welcome text',
       (WidgetTester tester) async {

--- a/test/features/family/family_management_test.dart
+++ b/test/features/family/family_management_test.dart
@@ -10,6 +10,7 @@ import 'package:appoint/providers/family_provider.dart';
 import 'package:appoint/providers/auth_provider.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../../fake_firebase_setup.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
@@ -139,10 +140,9 @@ class MockFamilyService implements FamilyService {
   }
 }
 
-void main() {
-  setUpAll(() async {
-    await initializeTestFirebase();
-  });
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
 
   group('Family Management System Tests', () {
     late ProviderContainer container;

--- a/test/features/family/otp_flow_test.dart
+++ b/test/features/family/otp_flow_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 // ignore_for_file: unused_local_variable, undefined_identifier, definitely_unassigned_late_local_variable
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../fake_firebase_setup.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:appoint/services/family_service.dart';
 import 'package:appoint/providers/otp_provider.dart';
 import 'package:appoint/providers/family_provider.dart';
@@ -10,10 +11,9 @@ import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
-void main() {
-  setUpAll(() async {
-    await initializeTestFirebase();
-  });
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
 
   group('OTP Flow', () {
     late MockFamilyService mockService;

--- a/test/features/studio_business/business_dashboard_screen_test.dart
+++ b/test/features/studio_business/business_dashboard_screen_test.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/features/studio_business/screens/business_dashboard_screen.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
+import '../../fake_firebase_setup.dart';
 
-void main() {
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
   group('BusinessDashboardScreen', () {
     testWidgets('renders correctly', (WidgetTester tester) async {
       await tester.pumpWidget(

--- a/test/features/studio_business/business_profile_screen_test.dart
+++ b/test/features/studio_business/business_profile_screen_test.dart
@@ -3,11 +3,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:appoint/features/studio_business/screens/business_profile_screen.dart';
 import '../../fake_firebase_setup.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 
-void main() {
-  setUpAll(() async {
-    await initializeTestFirebase();
-  });
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
   group('BusinessProfileScreen', () {
     testWidgets('renders correctly', (WidgetTester tester) async {
       await tester.pumpWidget(

--- a/test/integration/full_flow_test.dart
+++ b/test/integration/full_flow_test.dart
@@ -1,6 +1,10 @@
 @Skip('Integration test not yet implemented')
 import 'package:flutter_test/flutter_test.dart';
-void main() {
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
+import '../fake_firebase_setup.dart';
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
   group('Full Flow', () {
     test('placeholder', () async {
       // Placeholder for future login + booking simulation

--- a/test/models/admin_broadcast_message_test.dart
+++ b/test/models/admin_broadcast_message_test.dart
@@ -1,11 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/models/admin_broadcast_message.dart';
 import '../fake_firebase_setup.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 
-void main() {
-  setUpAll(() async {
-    await initializeTestFirebase();
-  });
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
 
   group('AdminBroadcastMessage Model', () {
     test('should correctly create a text broadcast message', () {

--- a/test/models/appointment_test.dart
+++ b/test/models/appointment_test.dart
@@ -3,11 +3,11 @@ import 'package:appoint/models/appointment.dart';
 import 'package:appoint/models/contact.dart';
 import 'package:appoint/models/invite.dart';
 import '../fake_firebase_setup.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 
-void main() {
-  setUpAll(() async {
-    await initializeTestFirebase();
-  });
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
 
   group('Appointment Model', () {
     test('should correctly create a scheduled appointment', () {

--- a/test/models/user_profile_test.dart
+++ b/test/models/user_profile_test.dart
@@ -1,11 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/models/user_profile.dart';
 import '../fake_firebase_setup.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 
-void main() {
-  setUpAll(() async {
-    await initializeTestFirebase();
-  });
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
 
   group('UserProfile Model', () {
     test('should correctly create a user profile', () {

--- a/test/otp_flow_test.dart
+++ b/test/otp_flow_test.dart
@@ -1,14 +1,12 @@
 import 'package:flutter_test/flutter_test.dart';
-
-// Replace with the real file & widget name for your app's entrypoint
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import './fake_firebase_setup.dart';
 
 // Flutter widgets & material controls
 
-void main() {
-  setUpAll(() async {
-    await initializeTestFirebase();
-  });
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
 
   testWidgets('OTP flow: send and verify code', (tester) async {}, skip: true);
 }

--- a/test/playtime/playtime_provider_test.dart
+++ b/test/playtime/playtime_provider_test.dart
@@ -7,11 +7,11 @@ import '../../lib/models/playtime_session.dart';
 import '../../lib/models/playtime_background.dart';
 import '../../lib/services/playtime_service.dart';
 import '../fake_firebase_setup.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 
-void main() {
-  setUpAll(() async {
-    await initializeTestFirebase();
-  });
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
 
   group('Playtime Provider Tests', () {
     late ProviderContainer container;

--- a/test/run_all_tests.dart
+++ b/test/run_all_tests.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
+import 'fake_firebase_setup.dart';
 
 // Import all test files
 import 'models/user_profile_test.dart' as user_profile_test;
@@ -11,7 +13,9 @@ import 'features/admin/admin_broadcast_screen_test.dart'
     as admin_broadcast_screen_test;
 import 'features/auth/login_screen_test.dart' as login_screen_test;
 
-void main() {
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
   group('All Tests', () {
     group('Model Tests', () {
       user_profile_test.main();

--- a/test/services/admin_service_test.dart
+++ b/test/services/admin_service_test.dart
@@ -1,13 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/services/admin_service.dart';
 import '../fake_firebase_setup.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
-void main() {
-  setUpAll(() async {
-    await initializeTestFirebase();
-  });
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
 
   group('AdminService', () {
       // ignore: unused_local_variable

--- a/test/services/broadcast_service_test.dart
+++ b/test/services/broadcast_service_test.dart
@@ -2,15 +2,15 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/services/broadcast_service.dart';
 import 'package:appoint/models/admin_broadcast_message.dart';
 import '../fake_firebase_setup.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
 
-void main() {
-  setUpAll(() async {
-    await initializeTestFirebase();
-  });
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
 
   group('BroadcastService', () {
       // ignore: unused_local_variable

--- a/test/whatsapp_share_test.dart
+++ b/test/whatsapp_share_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/services/whatsapp_share_service.dart';
 import 'package:appoint/models/smart_share_link.dart';
 import './fake_firebase_setup.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
@@ -11,10 +12,9 @@ class MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
 class MockFirebaseAnalytics extends Mock implements FirebaseAnalytics {}
 
 
-void main() {
-  setUpAll(() async {
-    await initializeTestFirebase();
-  });
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
 
   group('WhatsApp Share Service Tests', () {
     late WhatsAppShareService service;

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,9 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
+import 'fake_firebase_setup.dart';
 
-// Minimal smoke test that does not require Firebase initialization.
+// Minimal smoke test for the app.
 
-void main() {
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
   testWidgets('App smoke test', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(


### PR DESCRIPTION
## Summary
- update all tests to use `initializeTestFirebase()`
- wrap widget test setup in `MaterialApp`
- import the color shim for tests

## Testing
- `flutter pub get --offline`
- `flutter test --coverage` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_685ee4ced65c8324b7c2cd9491f1874d