### PR TITLE
Fix CI Verdaccio integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     env:
-      PUB_HOSTED_URL: https://pub.dev
+      PUB_HOSTED_URL: http://localhost:4873
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
     services:
@@ -44,20 +44,24 @@ jobs:
           for host in pub.dev storage.googleapis.com; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
-      - run: flutter pub get
-      - run: dart pub get
-      - run: dart run build_runner build --delete-conflicting-outputs
-      - name: Configure offline pub cache
-        run: echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
-      - name: Fetch dependencies offline
-        run: flutter pub get --offline
-      - run: flutter analyze
-      - run: dart analyze
-      - run: flutter test --coverage
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
           node-version: '16.x'
+      - name: Install Verdaccio
+        run: npm install -g verdaccio
+      - name: Start Verdaccio
+        run: verdaccio --config verdaccio.yaml & sleep 5
+      - name: Configure Pub Cache
+        run: |
+          echo "PUB_HOSTED_URL=http://localhost:4873" >> $GITHUB_ENV
+          echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
+      - run: flutter pub get
+      - run: dart pub get
+      - run: dart run build_runner build --delete-conflicting-outputs
+      - run: flutter analyze
+      - run: dart analyze
+      - run: flutter test --coverage
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
       - name: Start Firebase emulators
@@ -123,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     env:
-      PUB_HOSTED_URL: https://pub.dev
+      PUB_HOSTED_URL: http://localhost:4873
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
@@ -147,19 +151,23 @@ jobs:
           for host in pub.dev storage.googleapis.com; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
-      - run: flutter pub get
-      - run: dart pub get
-      - run: dart run build_runner build --delete-conflicting-outputs
-      - name: Configure offline pub cache
-        run: echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
-      - name: Fetch dependencies offline
-        run: flutter pub get --offline
-      - run: flutter analyze
-      - run: dart analyze
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
           node-version: '16.x'
+      - name: Install Verdaccio
+        run: npm install -g verdaccio
+      - name: Start Verdaccio
+        run: verdaccio --config verdaccio.yaml & sleep 5
+      - name: Configure Pub Cache
+        run: |
+          echo "PUB_HOSTED_URL=http://localhost:4873" >> $GITHUB_ENV
+          echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
+      - run: flutter pub get
+      - run: dart pub get
+      - run: dart run build_runner build --delete-conflicting-outputs
+      - run: flutter analyze
+      - run: dart analyze
       - run: dart test --coverage
       - run: dart test integration_test/
       - name: Build Web App
@@ -174,7 +182,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     env:
-      PUB_HOSTED_URL: https://pub.dev
+      PUB_HOSTED_URL: http://localhost:4873
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
@@ -198,13 +206,21 @@ jobs:
           for host in pub.dev storage.googleapis.com; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+      - name: Install Verdaccio
+        run: npm install -g verdaccio
+      - name: Start Verdaccio
+        run: verdaccio --config verdaccio.yaml & sleep 5
+      - name: Configure Pub Cache
+        run: |
+          echo "PUB_HOSTED_URL=http://localhost:4873" >> $GITHUB_ENV
+          echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
       - run: flutter pub get
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs
-      - name: Configure offline pub cache
-        run: echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
-      - name: Fetch dependencies offline
-        run: flutter pub get --offline
       - run: flutter analyze
       - run: dart analyze
       - run: flutter test --coverage
@@ -221,7 +237,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     env:
-      PUB_HOSTED_URL: https://pub.dev
+      PUB_HOSTED_URL: http://localhost:4873
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
@@ -245,13 +261,21 @@ jobs:
           for host in pub.dev storage.googleapis.com; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+      - name: Install Verdaccio
+        run: npm install -g verdaccio
+      - name: Start Verdaccio
+        run: verdaccio --config verdaccio.yaml & sleep 5
+      - name: Configure Pub Cache
+        run: |
+          echo "PUB_HOSTED_URL=http://localhost:4873" >> $GITHUB_ENV
+          echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
       - run: flutter pub get
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs
-      - name: Configure offline pub cache
-        run: echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
-      - name: Fetch dependencies offline
-        run: flutter pub get --offline
       - run: flutter analyze
       - run: dart analyze
       - run: flutter test --coverage
@@ -268,7 +292,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     env:
-      PUB_HOSTED_URL: https://pub.dev
+      PUB_HOSTED_URL: http://localhost:4873
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
@@ -292,13 +316,17 @@ jobs:
           for host in pub.dev storage.googleapis.com; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
+      - name: Install Verdaccio
+        run: npm install -g verdaccio
+      - name: Start Verdaccio
+        run: verdaccio --config verdaccio.yaml & sleep 5
+      - name: Configure Pub Cache
+        run: |
+          echo "PUB_HOSTED_URL=http://localhost:4873" >> $GITHUB_ENV
+          echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
       - run: flutter pub get
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs
-      - name: Configure offline pub cache
-        run: echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
-      - name: Fetch dependencies offline
-        run: flutter pub get --offline
       - run: flutter analyze
       - run: dart analyze
       - run: flutter test --coverage

--- a/verdaccio.yaml
+++ b/verdaccio.yaml
@@ -1,0 +1,15 @@
+storage: ./verdaccio-storage
+listen: 4873
+auth:
+  htpasswd:
+    file: ./htpasswd
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+packages:
+  '@*/*':
+    access: $all
+    publish: $all
+  '**':
+    access: $all
+    publish: $all


### PR DESCRIPTION
## Summary
- integrate Verdaccio package server in all CI jobs
- remove offline pub steps
- add Verdaccio config file

## Testing
- `dart test --coverage` *(fails: The current Flutter SDK version is 0.0.0-unknown)*

------
https://chatgpt.com/codex/tasks/task_e_685ee7c016a88324a3f1026dd49b20dd