### PR TITLE
Fix CI Flutter SDK setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,10 @@ jobs:
           FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
     steps:
       - uses: actions/checkout@v4
-      - name: Use bundled Flutter SDK
-        run: echo "${{ github.workspace }}/flutter_sdk/bin" >> $GITHUB_PATH
+      - name: Setup Flutter SDK
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.20.0'
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:
@@ -61,7 +63,10 @@ jobs:
       - run: dart run build_runner build --delete-conflicting-outputs
       - run: flutter analyze
       - run: dart analyze
-      - run: flutter test --coverage
+      - name: Validate Flutter SDK
+        run: |
+          flutter --version
+          flutter test --coverage
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
       - name: Start Firebase emulators
@@ -69,7 +74,7 @@ jobs:
           firebase emulators:start --only firestore,functions &
           echo $! > emulator.pid
       - run: flutter test --coverage
-      - run: dart test --coverage
+      - run: flutter test --coverage
       - run: dart test integration_test/
       - run: flutter build web
       - name: Stop emulators
@@ -86,8 +91,10 @@ jobs:
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
       - uses: actions/checkout@v4
-      - name: Use bundled Flutter SDK
-        run: echo "${{ github.workspace }}/flutter_sdk/bin" >> $GITHUB_PATH
+      - name: Setup Flutter SDK
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.20.0'
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:
@@ -132,8 +139,10 @@ jobs:
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
       - uses: actions/checkout@v4
-      - name: Use bundled Flutter SDK
-        run: echo "${{ github.workspace }}/flutter_sdk/bin" >> $GITHUB_PATH
+      - name: Setup Flutter SDK
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.20.0'
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:
@@ -168,7 +177,7 @@ jobs:
       - run: dart run build_runner build --delete-conflicting-outputs
       - run: flutter analyze
       - run: dart analyze
-      - run: dart test --coverage
+      - run: flutter test --coverage
       - run: dart test integration_test/
       - name: Build Web App
         run: flutter build web --release
@@ -187,8 +196,10 @@ jobs:
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
       - uses: actions/checkout@v4
-      - name: Use bundled Flutter SDK
-        run: echo "${{ github.workspace }}/flutter_sdk/bin" >> $GITHUB_PATH
+      - name: Setup Flutter SDK
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.20.0'
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:
@@ -224,7 +235,7 @@ jobs:
       - run: flutter analyze
       - run: dart analyze
       - run: flutter test --coverage
-      - run: dart test --coverage
+      - run: flutter test --coverage
       - run: dart test integration_test/
       - run: flutter build web
       - name: Run Smoke Tests
@@ -242,8 +253,10 @@ jobs:
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
       - uses: actions/checkout@v4
-      - name: Use bundled Flutter SDK
-        run: echo "${{ github.workspace }}/flutter_sdk/bin" >> $GITHUB_PATH
+      - name: Setup Flutter SDK
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.20.0'
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:
@@ -279,7 +292,7 @@ jobs:
       - run: flutter analyze
       - run: dart analyze
       - run: flutter test --coverage
-      - run: dart test --coverage
+      - run: flutter test --coverage
       - run: dart test integration_test/
       - run: flutter build web
       - name: Run Security Scan
@@ -297,8 +310,10 @@ jobs:
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
       - uses: actions/checkout@v4
-      - name: Use bundled Flutter SDK
-        run: echo "${{ github.workspace }}/flutter_sdk/bin" >> $GITHUB_PATH
+      - name: Setup Flutter SDK
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.20.0'
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:
@@ -330,7 +345,7 @@ jobs:
       - run: flutter analyze
       - run: dart analyze
       - run: flutter test --coverage
-      - run: dart test --coverage
+      - run: flutter test --coverage
       - run: dart test integration_test/
       - run: flutter build web
       - name: Notify on Success


### PR DESCRIPTION
## Summary
- install Flutter 3.20.0 in CI
- run `flutter --version` and tests to validate setup
- replace bare `dart test --coverage` with `flutter test --coverage`

## Testing
- `npm install -g firebase-tools` *(fails: blocked network when starting emulators)*
- `dart test --coverage` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eead455e08324813f60217ec2a203