### PR TITLE
Add ContentLibraryScreen and route

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../features/auth/home_screen.dart';
 import '../features/studio/studio_booking_screen.dart';
 import '../features/studio/studio_booking_confirm_screen.dart';
+import '../features/studio/ui/content_library_screen.dart';
 import '../features/booking/screens/chat_booking_screen.dart';
 import '../features/booking/booking_request_screen.dart';
 import '../features/dashboard/dashboard_screen.dart';
@@ -40,6 +41,11 @@ class AppRouter {
       case '/studio/confirm':
         return MaterialPageRoute(
           builder: (_) => const StudioBookingConfirmScreen(),
+          settings: settings,
+        );
+      case '/studio/library':
+        return MaterialPageRoute(
+          builder: (_) => const ContentLibraryScreen(),
           settings: settings,
         );
       case '/chat-booking':

--- a/lib/features/studio/ui/content_library_screen.dart
+++ b/lib/features/studio/ui/content_library_screen.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+/// TODO: Implement content list per spec §2.2
+class ContentLibraryScreen extends StatelessWidget {
+  const ContentLibraryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Content Library'),
+      ),
+      body: const ListView(
+        children: [
+          Center(
+            child: Padding(
+              padding: EdgeInsets.all(24),
+              child: Text('No content available yet'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/features/studio/content_library_screen_test.dart
+++ b/test/features/studio/content_library_screen_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/features/studio/ui/content_library_screen.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  group('ContentLibraryScreen', () {
+    testWidgets('shows placeholder text', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: ContentLibraryScreen(),
+        ),
+      );
+
+      expect(find.text('No content available yet'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold `ContentLibraryScreen` under `lib/features/studio/ui`
- hook `/studio/library` route in the router
- test widget placeholder for `ContentLibraryScreen`

## Testing
- `dart format lib/features/studio/ui/content_library_screen.dart lib/config/routes.dart test/features/studio/content_library_screen_test.dart`
- `flutter test` *(fails: Flutter SDK version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_685eeb3a971883249676b3b5245452ff