### PR TITLE
Add stub Content Library screen

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../features/auth/home_screen.dart';
 import '../features/studio/studio_booking_screen.dart';
 import '../features/studio/studio_booking_confirm_screen.dart';
+import '../features/studio/ui/content_library_screen.dart';
 import '../features/booking/screens/chat_booking_screen.dart';
 import '../features/booking/booking_request_screen.dart';
 import '../features/dashboard/dashboard_screen.dart';
@@ -40,6 +41,11 @@ class AppRouter {
       case '/studio/confirm':
         return MaterialPageRoute(
           builder: (_) => const StudioBookingConfirmScreen(),
+          settings: settings,
+        );
+      case '/studio/library':
+        return MaterialPageRoute(
+          builder: (_) => const ContentLibraryScreen(),
           settings: settings,
         );
       case '/chat-booking':
@@ -212,6 +218,7 @@ class MeetingDetailsScreen extends StatelessWidget {
 
 final Map<String, WidgetBuilder> appRoutes = {
   // ... existing code ...
+  '/studio/library': (context) => const ContentLibraryScreen(),
   '/business/dashboard': (context) => const BusinessDashboardScreen(),
   // ... existing code ...
 };

--- a/lib/features/studio/ui/content_library_screen.dart
+++ b/lib/features/studio/ui/content_library_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class ContentLibraryScreen extends StatelessWidget {
+  const ContentLibraryScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Content Library')),
+      body: const Center(child: Text('No content yet.')), // TODO: implement per spec §2.2
+    );
+  }
+}

--- a/test/features/studio/content_library_screen_test.dart
+++ b/test/features/studio/content_library_screen_test.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/features/studio/ui/content_library_screen.dart';
+
+void main() {
+  testWidgets('ContentLibraryScreen shows placeholder', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: ContentLibraryScreen()));
+    expect(find.text('No content yet.'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold a basic `ContentLibraryScreen`
- route `/studio/library` to the new screen
- add widget test for the placeholder text

## Testing
- `flutter analyze`
- `flutter test --coverage` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_685eed4fe98083249e11719212fb45ac