### PR TITLE
Add comments screen stub

### DIFF
--- a/lib/features/personal_app/ui/comments_screen.dart
+++ b/lib/features/personal_app/ui/comments_screen.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+/// TODO: Implement fetching and posting comments
+class CommentsScreen extends StatelessWidget {
+  const CommentsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Comments'),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView.builder(
+              itemCount: 3,
+              itemBuilder: (context, index) => const CommentCard(),
+            ),
+          ),
+          const Divider(height: 1),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+            child: Row(
+              children: [
+                const Expanded(
+                  child: TextField(
+                    decoration: InputDecoration(hintText: 'Add a comment...'),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.send),
+                  onPressed: () {},
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class CommentCard extends StatelessWidget {
+  const CommentCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Card(
+      child: ListTile(
+        title: Text(''),
+      ),
+    );
+  }
+}

--- a/test/features/personal_app/comments_screen_test.dart
+++ b/test/features/personal_app/comments_screen_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/features/personal_app/ui/comments_screen.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  group('CommentsScreen', () {
+    testWidgets('shows input field and send button', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: CommentsScreen(),
+        ),
+      );
+
+      expect(find.byType(TextField), findsOneWidget);
+      expect(find.byIcon(Icons.send), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold `CommentsScreen` under personal_app ui
- add widget test ensuring presence of input field and send button

## Testing
- `dart test --coverage=coverage` *(fails: Failed to load various tests)*

------
https://chatgpt.com/codex/tasks/task_e_685eef03ce148324afe5fdc0983cba40