### PR TITLE
feat: add content detail screen stub

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -24,6 +24,7 @@ import '../models/invite.dart';
 import 'package:appoint/features/studio_business/screens/business_dashboard_screen.dart';
 import 'package:appoint/features/studio_business/screens/business_profile_screen.dart';
 import '../features/invite/invite_list_screen.dart';
+import '../features/personal_app/ui/content_detail_screen.dart';
 
 class AppRouter {
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
@@ -135,6 +136,13 @@ class AppRouter {
         final invite = settings.arguments as Invite;
         return MaterialPageRoute(
           builder: (_) => InviteDetailScreen(invite: invite),
+          settings: settings,
+        );
+      case '/content/:id':
+        final args = settings.arguments as Map<String, dynamic>? ?? {};
+        final id = args['id'] as String? ?? '';
+        return MaterialPageRoute(
+          builder: (_) => ContentDetailScreen(id: id),
           settings: settings,
         );
       case '/booking/details':

--- a/lib/features/personal_app/ui/content_detail_screen.dart
+++ b/lib/features/personal_app/ui/content_detail_screen.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+// TODO per spec §2.1
+class ContentDetailScreen extends StatelessWidget {
+  final String id;
+
+  const ContentDetailScreen({super.key, required this.id});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Content Detail'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: const [
+            SizedBox(height: 24),
+            FlutterLogo(size: 200),
+            SizedBox(height: 24),
+            Text(
+              'Content Title Placeholder',
+              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+            ),
+            SizedBox(height: 12),
+            Text('Content description coming soon.'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/personal_app/content_detail_screen_test.dart
+++ b/test/features/personal_app/content_detail_screen_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../fake_firebase_setup.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
+import 'package:appoint/features/personal_app/ui/content_detail_screen.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  group('ContentDetailScreen', () {
+    testWidgets('shows placeholder title', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          child: const MaterialApp(
+            home: ContentDetailScreen(id: '1'),
+          ),
+        ),
+      );
+
+      expect(find.text('Content Title Placeholder'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- stub out ContentDetailScreen
- register '/content/:id' route
- test widget placeholder

## Testing
- `/workspace/flutter_sdk/bin/flutter pub get --offline` *(fails: intl version solving failed)*
- `/workspace/flutter_sdk/bin/dart test --coverage=coverage` *(fails: some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_685eeef7b3a08324a546274d182579b8