### PR TITLE
Add profile screens with tests

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -7,7 +7,8 @@ import '../features/studio/ui/content_library_screen.dart';
 import '../features/booking/screens/chat_booking_screen.dart';
 import '../features/booking/booking_request_screen.dart';
 import '../features/dashboard/dashboard_screen.dart';
-import '../features/profile/user_profile_screen.dart';
+import '../features/personal_app/ui/profile_screen.dart';
+import '../features/personal_app/ui/edit_profile_screen.dart';
 import '../features/admin/admin_dashboard_screen.dart';
 import '../features/family/widgets/invitation_modal.dart';
 import '../features/family/screens/family_dashboard_screen.dart';
@@ -65,7 +66,12 @@ class AppRouter {
         );
       case '/profile':
         return MaterialPageRoute(
-          builder: (_) => const UserProfileScreen(),
+          builder: (_) => const ProfileScreen(),
+          settings: settings,
+        );
+      case '/profile/edit':
+        return MaterialPageRoute(
+          builder: (_) => const EditProfileScreen(),
           settings: settings,
         );
       case '/admin/dashboard':

--- a/lib/features/personal_app/ui/edit_profile_screen.dart
+++ b/lib/features/personal_app/ui/edit_profile_screen.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+class EditProfileScreen extends StatelessWidget {
+  const EditProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Edit Profile')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            GestureDetector(
+              onTap: () {},
+              child: const CircleAvatar(
+                radius: 40,
+                child: Icon(Icons.person, size: 40),
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              decoration: const InputDecoration(labelText: 'Username'),
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              decoration: const InputDecoration(labelText: 'Bio'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Save'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/personal_app/ui/profile_screen.dart
+++ b/lib/features/personal_app/ui/profile_screen.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+class ProfileScreen extends StatelessWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Profile')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            const CircleAvatar(
+              radius: 40,
+              child: Icon(Icons.person, size: 40),
+            ),
+            const SizedBox(height: 16),
+            const Text('Username'),
+            const SizedBox(height: 8),
+            const Text('Bio'),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => Navigator.pushNamed(context, '/profile/edit'),
+              child: const Text('Edit'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/personal_app/edit_profile_screen_test.dart
+++ b/test/features/personal_app/edit_profile_screen_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/features/personal_app/ui/edit_profile_screen.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  group('EditProfileScreen', () {
+    testWidgets('renders form fields and save button', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: EditProfileScreen()));
+
+      expect(find.byType(CircleAvatar), findsOneWidget);
+      expect(find.byType(TextField), findsNWidgets(2));
+      expect(find.text('Username'), findsOneWidget);
+      expect(find.text('Bio'), findsOneWidget);
+      expect(find.text('Save'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/personal_app/profile_screen_test.dart
+++ b/test/features/personal_app/profile_screen_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/features/personal_app/ui/profile_screen.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  group('ProfileScreen', () {
+    testWidgets('renders avatar, text, and edit button', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: ProfileScreen()));
+
+      expect(find.byType(CircleAvatar), findsOneWidget);
+      expect(find.text('Username'), findsOneWidget);
+      expect(find.text('Bio'), findsOneWidget);
+      expect(find.text('Edit'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold stub Profile screen with avatar, username, bio, and Edit button
- add Edit Profile screen stub with avatar picker and form fields
- hook `/profile` and `/profile/edit` routes into router
- test both screens render expected widgets

## Testing
- `dart test test/features/personal_app/profile_screen_test.dart` *(fails: Dart library `dart:ui` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eef103f10832489452c5ffb00978d