### PR TITLE
Finalize Comments screen UI and tests

### DIFF
--- a/lib/features/studio/ui/content_library_screen.dart
+++ b/lib/features/studio/ui/content_library_screen.dart
@@ -10,7 +10,7 @@ class ContentLibraryScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Content Library'),
       ),
-      body: const ListView(
+      body: ListView(
         children: [
           Center(
             child: Padding(

--- a/lib/models/comment.dart
+++ b/lib/models/comment.dart
@@ -1,0 +1,11 @@
+class Comment {
+  final String id;
+  final String text;
+  final DateTime createdAt;
+
+  Comment({
+    required this.id,
+    required this.text,
+    required this.createdAt,
+  });
+}

--- a/lib/services/comment_service.dart
+++ b/lib/services/comment_service.dart
@@ -1,0 +1,18 @@
+import 'dart:async';
+
+import '../models/comment.dart';
+
+/// Simple comment service used for the comments UI widget tests.
+class CommentService {
+  Future<List<Comment>> fetchComments() async {
+    return [
+      Comment(id: '1', text: 'First!', createdAt: DateTime.now()),
+      Comment(id: '2', text: 'Nice post', createdAt: DateTime.now()),
+    ];
+  }
+
+  Future<void> postComment(String text) async {
+    // Stubbed network call
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+}

--- a/test/features/personal_app/comments_screen_test.dart
+++ b/test/features/personal_app/comments_screen_test.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:appoint/features/personal_app/ui/comments_screen.dart';
+import '../../fake_firebase_setup.dart';
 
 Future<void> main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
   group('CommentsScreen', () {
     testWidgets('shows input field and send button', (WidgetTester tester) async {
       await tester.pumpWidget(


### PR DESCRIPTION
## Summary
- build out `CommentsScreen` with stateful widget
- add simple `Comment` model and `CommentService` stubs
- update comments widget test with firebase setup
- fix minor compile error in `ContentLibraryScreen`

## Testing
- `flutter analyze` *(fails: 47 issues found)*
- `flutter test --coverage test/features/personal_app/comments_screen_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_685ef1e661888324a0fd40c7a1711257