### PR TITLE
Fix search screen scaffold and clean imports

### DIFF
--- a/lib/features/admin/admin_broadcast_screen.dart
+++ b/lib/features/admin/admin_broadcast_screen.dart
@@ -5,7 +5,6 @@ import 'package:image_picker/image_picker.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'dart:io';
 import 'package:appoint/utils/color_extension.dart';
-import 'package:flutter/painting.dart';
 import 'package:appoint/l10n/app_localizations.dart';
 import 'package:appoint/services/broadcast_service.dart';
 import 'package:appoint/models/admin_broadcast_message.dart';

--- a/lib/features/admin/admin_dashboard_screen.dart
+++ b/lib/features/admin/admin_dashboard_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fl_chart/fl_chart.dart';
-import '../../extensions/fl_chart_color_shim.dart';
 import '../../widgets/admin_guard.dart';
 import '../../providers/admin_provider.dart';
 import '../../models/admin_dashboard_stats.dart';

--- a/lib/features/ambassador_dashboard_screen.dart
+++ b/lib/features/ambassador_dashboard_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fl_chart/fl_chart.dart';
-import '../extensions/fl_chart_color_shim.dart';
 import '../providers/ambassador_data_provider.dart';
 import '../models/ambassador_stats.dart';
 import '../models/branch.dart';

--- a/lib/features/booking/booking_request_screen.dart
+++ b/lib/features/booking/booking_request_screen.dart
@@ -5,7 +5,6 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import '../../services/maps_service.dart';
 import '../../services/location_service.dart';
 import '../../providers/branch_provider.dart';
-import 'dart:io' show Platform;
 import 'package:flutter/foundation.dart' show kIsWeb;
 
 class BookingRequestScreen extends ConsumerStatefulWidget {

--- a/lib/features/personal_app/ui/search_screen.dart
+++ b/lib/features/personal_app/ui/search_screen.dart
@@ -16,9 +16,10 @@ class SearchScreen extends StatelessWidget {
             padding: EdgeInsets.all(16),
             child: TextField(),
           ),
-          const Expanded(
-            child: ListView(
-              children: [],
+          Expanded(
+            child: ListView.builder(
+              itemCount: 0,
+              itemBuilder: (context, index) => const SizedBox.shrink(),
             ),
           ),
         ],

--- a/lib/features/playtime/playtime_hub_screen.dart
+++ b/lib/features/playtime/playtime_hub_screen.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'dart:ui' show Offset;
-import 'package:flutter/painting.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 

--- a/lib/features/playtime/screens/game_list_screen.dart
+++ b/lib/features/playtime/screens/game_list_screen.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'dart:ui' show Offset;
-import 'package:flutter/painting.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 

--- a/lib/features/playtime/screens/parent_dashboard_screen.dart
+++ b/lib/features/playtime/screens/parent_dashboard_screen.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'dart:ui' show Offset;
-import 'package:flutter/painting.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 

--- a/lib/features/playtime/screens/playtime_landing_screen.dart
+++ b/lib/features/playtime/screens/playtime_landing_screen.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'dart:ui' show Offset;
-import 'package:flutter/painting.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 

--- a/lib/features/studio/ui/content_library_screen.dart
+++ b/lib/features/studio/ui/content_library_screen.dart
@@ -10,7 +10,7 @@ class ContentLibraryScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Content Library'),
       ),
-      body: const ListView(
+      body: ListView(
         children: [
           Center(
             child: Padding(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,7 +10,6 @@ import 'config/theme.dart';
 import 'firebase_options.dart';
 import 'services/custom_deep_link_service.dart';
 import 'services/notification_service.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
 
 Future<void> appMain() async {
   WidgetsFlutterBinding.ensureInitialized();

--- a/test/ambassador_dashboard_test.dart
+++ b/test/ambassador_dashboard_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:appoint/features/ambassador_dashboard_screen.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:appoint/providers/ambassador_data_provider.dart';
 import 'package:appoint/services/ambassador_service.dart';
 import 'package:appoint/models/ambassador_stats.dart';

--- a/test/ambassador_quota_service_test.dart
+++ b/test/ambassador_quota_service_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/services/ambassador_quota_service.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'fake_firebase_setup.dart';
 
 Future<void> main() async {

--- a/test/booking_service_test.dart
+++ b/test/booking_service_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:appoint/features/booking/services/booking_service.dart';
 import 'package:appoint/models/booking.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import './fake_firebase_setup.dart';
 import './fake_firebase_firestore.dart';
 

--- a/test/family_integration_test.dart
+++ b/test/family_integration_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/models/family_link.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'fake_firebase_setup.dart';
 
 Future<void> main() async {

--- a/test/features/admin/admin_broadcast_screen_test.dart
+++ b/test/features/admin/admin_broadcast_screen_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../fake_firebase_setup.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:appoint/features/admin/admin_broadcast_screen.dart';
 import 'package:appoint/l10n/app_localizations.dart';
 import 'package:mockito/mockito.dart';

--- a/test/features/admin/admin_broadcast_test.dart
+++ b/test/features/admin/admin_broadcast_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/models/admin_broadcast_message.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import '../../fake_firebase_setup.dart';
 
 Future<void> main() async {

--- a/test/features/admin/admin_demo_screens_test.dart
+++ b/test/features/admin/admin_demo_screens_test.dart
@@ -6,7 +6,6 @@ import 'package:appoint/features/admin/admin_monetization_control_demo_screen.da
 import 'package:appoint/features/admin/admin_broadcast_system_demo_screen.dart';
 import 'package:appoint/features/admin/admin_error_logs_demo_screen.dart';
 import 'package:appoint/features/admin/admin_demo_panel_screen.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import '../../fake_firebase_setup.dart';
 
 Future<void> main() async {

--- a/test/features/admin/admin_panel_audit_test.dart
+++ b/test/features/admin/admin_panel_audit_test.dart
@@ -6,7 +6,6 @@ import 'package:appoint/features/admin/admin_demo_panel_screen.dart';
 import 'package:appoint/features/admin/admin_monetization_control_demo_screen.dart';
 import 'package:appoint/features/admin/admin_broadcast_system_demo_screen.dart';
 import 'package:appoint/features/admin/admin_error_logs_demo_screen.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import '../../fake_firebase_setup.dart';
 
 Future<void> main() async {

--- a/test/features/admin/admin_panel_integration_test.dart
+++ b/test/features/admin/admin_panel_integration_test.dart
@@ -15,7 +15,6 @@ import 'package:appoint/models/admin_dashboard_stats.dart';
 import 'package:appoint/models/admin_broadcast_message.dart';
 import 'package:appoint/l10n/app_localizations.dart';
 import '../../fake_firebase_setup.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 
 // Generate mocks
 @GenerateMocks([AdminService, FirebaseAuth, FirebaseFirestore])

--- a/test/features/admin/admin_role_test.dart
+++ b/test/features/admin/admin_role_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:appoint/providers/admin_provider.dart';
 import '../../fake_firebase_setup.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:mockito/mockito.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 

--- a/test/features/ambassador/ambassador_dashboard_test.dart
+++ b/test/features/ambassador/ambassador_dashboard_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../../lib/models/ambassador_stats.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import '../../fake_firebase_setup.dart';
 
 Future<void> main() async {

--- a/test/features/auth/login_screen_test.dart
+++ b/test/features/auth/login_screen_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../fake_firebase_setup.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:appoint/features/auth/login_screen.dart';
 
 Future<void> main() async {

--- a/test/features/booking/chat_booking_test.dart
+++ b/test/features/booking/chat_booking_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import '../../fake_firebase_setup.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:appoint/features/booking/screens/chat_booking_screen.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';

--- a/test/features/business/business_dashboard_screen_test.dart
+++ b/test/features/business/business_dashboard_screen_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:appoint/features/business/screens/business_dashboard_screen.dart';
 import '../../fake_firebase_setup.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 

--- a/test/features/family/family_management_test.dart
+++ b/test/features/family/family_management_test.dart
@@ -10,7 +10,6 @@ import 'package:appoint/providers/family_provider.dart';
 import 'package:appoint/providers/auth_provider.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../../fake_firebase_setup.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 

--- a/test/features/family/otp_flow_test.dart
+++ b/test/features/family/otp_flow_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 // ignore_for_file: unused_local_variable, undefined_identifier, definitely_unassigned_late_local_variable
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../fake_firebase_setup.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:appoint/services/family_service.dart';
 import 'package:appoint/providers/otp_provider.dart';
 import 'package:appoint/providers/family_provider.dart';

--- a/test/features/personal_app/search_screen_test.dart
+++ b/test/features/personal_app/search_screen_test.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/features/personal_app/ui/search_screen.dart';
+import '../../fake_firebase_setup.dart';
 
-void main() {
+Future<void> main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
 
   group('SearchScreen', () {
     testWidgets('shows search field', (WidgetTester tester) async {

--- a/test/features/studio_business/business_dashboard_screen_test.dart
+++ b/test/features/studio_business/business_dashboard_screen_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/features/studio_business/screens/business_dashboard_screen.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import '../../fake_firebase_setup.dart';
 
 Future<void> main() async {

--- a/test/features/studio_business/business_profile_screen_test.dart
+++ b/test/features/studio_business/business_profile_screen_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:appoint/features/studio_business/screens/business_profile_screen.dart';
 import '../../fake_firebase_setup.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 
 Future<void> main() async {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/integration/full_flow_test.dart
+++ b/test/integration/full_flow_test.dart
@@ -1,6 +1,5 @@
 @Skip('Integration test not yet implemented')
 import 'package:flutter_test/flutter_test.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import '../fake_firebase_setup.dart';
 Future<void> main() async {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/models/admin_broadcast_message_test.dart
+++ b/test/models/admin_broadcast_message_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/models/admin_broadcast_message.dart';
 import '../fake_firebase_setup.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 
 Future<void> main() async {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/models/appointment_test.dart
+++ b/test/models/appointment_test.dart
@@ -3,7 +3,6 @@ import 'package:appoint/models/appointment.dart';
 import 'package:appoint/models/contact.dart';
 import 'package:appoint/models/invite.dart';
 import '../fake_firebase_setup.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 
 Future<void> main() async {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/models/user_profile_test.dart
+++ b/test/models/user_profile_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/models/user_profile.dart';
 import '../fake_firebase_setup.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 
 Future<void> main() async {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/otp_flow_test.dart
+++ b/test/otp_flow_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import './fake_firebase_setup.dart';
 
 // Flutter widgets & material controls

--- a/test/playtime/playtime_provider_test.dart
+++ b/test/playtime/playtime_provider_test.dart
@@ -7,7 +7,6 @@ import '../../lib/models/playtime_session.dart';
 import '../../lib/models/playtime_background.dart';
 import '../../lib/services/playtime_service.dart';
 import '../fake_firebase_setup.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 
 Future<void> main() async {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/run_all_tests.dart
+++ b/test/run_all_tests.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'fake_firebase_setup.dart';
 
 // Import all test files

--- a/test/services/admin_service_test.dart
+++ b/test/services/admin_service_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/services/admin_service.dart';
 import '../fake_firebase_setup.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 

--- a/test/services/broadcast_service_test.dart
+++ b/test/services/broadcast_service_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/services/broadcast_service.dart';
 import 'package:appoint/models/admin_broadcast_message.dart';
 import '../fake_firebase_setup.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 

--- a/test/whatsapp_share_test.dart
+++ b/test/whatsapp_share_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/services/whatsapp_share_service.dart';
 import 'package:appoint/models/smart_share_link.dart';
 import './fake_firebase_setup.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'fake_firebase_setup.dart';
 
 // Minimal smoke test for the app.


### PR DESCRIPTION
## Summary
- clean imports in multiple files
- add list builder placeholder to SearchScreen
- update SearchScreen test with Firebase setup
- remove unused color shim imports across tests
- fix constant ListView in content library screen

## Testing
- `flutter analyze`
- `flutter test --coverage` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_685ef26c3db08324bfc18c5efb8a5499