### PR TITLE
Add notifications screen stub

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -26,6 +26,7 @@ import 'package:appoint/features/studio_business/screens/business_dashboard_scre
 import 'package:appoint/features/studio_business/screens/business_profile_screen.dart';
 import '../features/invite/invite_list_screen.dart';
 import '../features/personal_app/ui/search_screen.dart';
+import '../features/personal_app/ui/notifications_screen.dart';
 
 class AppRouter {
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
@@ -164,6 +165,11 @@ class AppRouter {
           builder: (_) => const InviteListScreen(),
           settings: settings,
         );
+      case '/notifications':
+        return MaterialPageRoute(
+          builder: (_) => const NotificationsScreen(),
+          settings: settings,
+        );
       case '/search':
         return MaterialPageRoute(
           builder: (_) => const SearchScreen(),
@@ -231,5 +237,6 @@ class MeetingDetailsScreen extends StatelessWidget {
 final Map<String, WidgetBuilder> appRoutes = {
   // ... existing code ...
   '/business/dashboard': (context) => const BusinessDashboardScreen(),
+  '/notifications': (context) => const NotificationsScreen(),
   // ... existing code ...
 };

--- a/lib/features/personal_app/ui/notifications_screen.dart
+++ b/lib/features/personal_app/ui/notifications_screen.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+/// TODO: implement per spec §2.1
+class NotificationsScreen extends StatelessWidget {
+  const NotificationsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Notifications'),
+      ),
+      body: ListView.builder(
+        itemCount: 3,
+        itemBuilder: (context, index) => const ListTile(),
+      ),
+    );
+  }
+}

--- a/test/features/personal_app/notifications_screen_test.dart
+++ b/test/features/personal_app/notifications_screen_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/features/personal_app/ui/notifications_screen.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('NotificationsScreen', () {
+    testWidgets('shows placeholder list', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: NotificationsScreen(),
+        ),
+      );
+
+      expect(find.byType(ListTile), findsNWidgets(3));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add NotificationsScreen scaffold
- hook up NotificationsScreen in router
- write widget test for NotificationsScreen

## Testing
- `flutter analyze`
- `flutter test --coverage test/features/personal_app/notifications_screen_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_685ef3f86e388324b7ac72f7dc362e45