### PR TITLE
Stub settings screen

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -26,6 +26,7 @@ import 'package:appoint/features/studio_business/screens/business_dashboard_scre
 import 'package:appoint/features/studio_business/screens/business_profile_screen.dart';
 import '../features/invite/invite_list_screen.dart';
 import '../features/personal_app/ui/search_screen.dart';
+import '../features/personal_app/ui/settings_screen.dart';
 
 class AppRouter {
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
@@ -162,6 +163,11 @@ class AppRouter {
       case '/invite/list':
         return MaterialPageRoute(
           builder: (_) => const InviteListScreen(),
+          settings: settings,
+        );
+      case '/settings':
+        return MaterialPageRoute(
+          builder: (_) => const SettingsScreen(),
           settings: settings,
         );
       case '/search':

--- a/lib/features/personal_app/ui/settings_screen.dart
+++ b/lib/features/personal_app/ui/settings_screen.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+/// Basic settings screen with dark mode and notification toggles.
+class SettingsScreen extends StatefulWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  bool _darkMode = false;
+  bool _notifications = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: ListView(
+        children: [
+          SwitchListTile(
+            title: const Text('Dark Mode'),
+            value: _darkMode,
+            onChanged: (v) => setState(() => _darkMode = v),
+          ),
+          SwitchListTile(
+            title: const Text('Notifications'),
+            value: _notifications,
+            onChanged: (v) => setState(() => _notifications = v),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: ElevatedButton(
+              onPressed: () {},
+              child: const Text('Sign Out'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/features/personal_app/settings_screen_test.dart
+++ b/test/features/personal_app/settings_screen_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/features/personal_app/ui/settings_screen.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SettingsScreen', () {
+    testWidgets('toggles switch and taps sign out', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SettingsScreen(),
+        ),
+      );
+
+      expect(find.byType(SwitchListTile), findsNWidgets(2));
+      expect(find.text('Sign Out'), findsOneWidget);
+
+      await tester.tap(find.byType(SwitchListTile).first);
+      await tester.pump();
+
+      final firstSwitch =
+          tester.widget<SwitchListTile>(find.byType(SwitchListTile).first);
+      expect(firstSwitch.value, isTrue);
+
+      await tester.tap(find.text('Sign Out'));
+      await tester.pump();
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a basic settings screen with toggles for Dark Mode and Notifications
- register `/settings` in the router
- test toggling a switch and tapping Sign Out

## Testing
- `flutter analyze` *(fails: network access required)*
- `flutter test --coverage test/features/personal_app/settings_screen_test.dart` *(fails: network access required)*
- `dart test --coverage` *(fails: Flutter SDK version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_685ef40e02a4832481c45388efe98963