### PR TITLE
Add reusable Error and Empty screens

### DIFF
--- a/lib/common/ui/empty_screen.dart
+++ b/lib/common/ui/empty_screen.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+/// Generic screen to display an empty state with an action button.
+class EmptyScreen extends StatelessWidget {
+  final String subtitle;
+  final String actionLabel;
+  final VoidCallback onAction;
+
+  const EmptyScreen({
+    super.key,
+    required this.subtitle,
+    required this.actionLabel,
+    required this.onAction,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(subtitle, textAlign: TextAlign.center),
+          const SizedBox(height: 24),
+          ElevatedButton(
+            onPressed: onAction,
+            child: Text(actionLabel),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/common/ui/error_screen.dart
+++ b/lib/common/ui/error_screen.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+/// Generic screen to display an error with a retry option.
+class ErrorScreen extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+
+  const ErrorScreen({
+    super.key,
+    required this.message,
+    required this.onRetry,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.error, size: 64, color: Colors.red),
+          const SizedBox(height: 16),
+          Text(message, textAlign: TextAlign.center),
+          const SizedBox(height: 24),
+          ElevatedButton(
+            onPressed: onRetry,
+            child: const Text('Retry'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/personal_app/home_feed_screen.dart
+++ b/lib/features/personal_app/home_feed_screen.dart
@@ -1,12 +1,33 @@
 import 'package:flutter/material.dart';
+import 'package:appoint/common/ui/error_screen.dart';
+import 'package:appoint/common/ui/empty_screen.dart';
 
 class HomeFeedScreen extends StatelessWidget {
   const HomeFeedScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(child: Text('Home Feed Screen')),
+    const hasError = false; // Placeholder for error state
+    const isEmpty = false; // Placeholder for empty state
+
+    Widget body;
+    if (hasError) {
+      body = ErrorScreen(
+        message: 'Something went wrong',
+        onRetry: () {},
+      );
+    } else if (isEmpty) {
+      body = EmptyScreen(
+        subtitle: 'No posts yet',
+        actionLabel: 'Refresh',
+        onAction: () {},
+      );
+    } else {
+      body = const Center(child: Text('Home Feed Screen'));
+    }
+
+    return Scaffold(
+      body: body,
     );
   }
 }

--- a/test/common/ui/empty_screen_test.dart
+++ b/test/common/ui/empty_screen_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/common/ui/empty_screen.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('EmptyScreen', () {
+    testWidgets('shows subtitle and action button', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EmptyScreen(
+            subtitle: 'Nothing here',
+            actionLabel: 'Add',
+            onAction: () {},
+          ),
+        ),
+      );
+
+      expect(find.text('Nothing here'), findsOneWidget);
+      expect(find.text('Add'), findsOneWidget);
+      expect(find.byType(ElevatedButton), findsOneWidget);
+    });
+  });
+}

--- a/test/common/ui/error_screen_test.dart
+++ b/test/common/ui/error_screen_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/common/ui/error_screen.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ErrorScreen', () {
+    testWidgets('shows icon, message and retry button', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ErrorScreen(
+            message: 'Failed',
+            onRetry: () {},
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.error), findsOneWidget);
+      expect(find.text('Failed'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+      expect(find.byType(ElevatedButton), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add generic `ErrorScreen` widget
- add generic `EmptyScreen` widget
- show the new screens conditionally in `HomeFeedScreen`
- test the new widgets

## Testing
- `flutter analyze`
- `flutter test --coverage test/common/ui/error_screen_test.dart test/common/ui/empty_screen_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_685ef41cd9d88324817a4982bcce73d9