### PR TITLE
Add scaffolded error and empty screens

### DIFF
--- a/lib/common/ui/empty_screen.dart
+++ b/lib/common/ui/empty_screen.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+class EmptyScreen extends StatelessWidget {
+  final String message;
+  final VoidCallback? onExplore;
+
+  const EmptyScreen({super.key, this.message = 'Nothing here yet', this.onExplore});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(message, textAlign: TextAlign.center),
+          const SizedBox(height: 24),
+          ElevatedButton(
+            onPressed: onExplore,
+            child: const Text('Explore'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/common/ui/error_screen.dart
+++ b/lib/common/ui/error_screen.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class ErrorScreen extends StatelessWidget {
+  final String message;
+  final VoidCallback? onRetry;
+
+  const ErrorScreen({super.key, this.message = 'Something went wrong', this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.error, size: 72, color: Colors.red),
+          const SizedBox(height: 16),
+          Text(message, textAlign: TextAlign.center),
+          const SizedBox(height: 24),
+          ElevatedButton(
+            onPressed: onRetry,
+            child: const Text('Retry'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/personal_app/ui/home_feed_screen.dart
+++ b/lib/features/personal_app/ui/home_feed_screen.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import '../../../common/ui/error_screen.dart';
+import '../../../common/ui/empty_screen.dart';
+
+class HomeFeedScreen extends StatelessWidget {
+  const HomeFeedScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // Stubbed booleans for demonstration
+    const hasError = false;
+    const isEmpty = true;
+
+    if (hasError) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Home')),
+        body: ErrorScreen(
+          onRetry: () {},
+        ),
+      );
+    }
+
+    if (isEmpty) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Home')),
+        body: EmptyScreen(
+          onExplore: () {},
+        ),
+      );
+    }
+
+    return const Scaffold(
+      body: Center(child: Text('Home Feed Screen')),
+    );
+  }
+}

--- a/test/common/ui/empty_screen_test.dart
+++ b/test/common/ui/empty_screen_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:appoint/common/ui/empty_screen.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('EmptyScreen', () {
+    testWidgets('shows placeholder and explore button', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: EmptyScreen(),
+        ),
+      );
+
+      expect(find.text('Nothing here yet'), findsOneWidget);
+      expect(find.text('Explore'), findsOneWidget);
+    });
+  });
+}

--- a/test/common/ui/error_screen_test.dart
+++ b/test/common/ui/error_screen_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:appoint/common/ui/error_screen.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ErrorScreen', () {
+    testWidgets('shows message and retry button', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: ErrorScreen(),
+        ),
+      );
+
+      expect(find.text('Something went wrong'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+      expect(find.byIcon(Icons.error), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `ErrorScreen` and `EmptyScreen` widgets
- integrate them in a stubbed `HomeFeedScreen`
- add widget tests for the new screens

## Testing
- `flutter analyze` *(fails: Unable to 'pub upgrade' flutter tool)*
- `flutter test --coverage test/common/ui/error_screen_test.dart test/common/ui/empty_screen_test.dart` *(fails: Unable to 'pub upgrade' flutter tool)*

------
https://chatgpt.com/codex/tasks/task_e_685ef87575908324ad260c9e9937165b