### PR TITLE
Fix SearchScreen analysis warnings and tests

### DIFF
--- a/lib/auth_wrapper.dart
+++ b/lib/auth_wrapper.dart
@@ -17,12 +17,8 @@ class AuthWrapper extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isLoggedIn = false;
-    if (isLoggedIn) {
-      Navigator.pushNamed(context, '/home');
-    } else {
-      Navigator.pushNamed(context, '/login');
-    }
+    // TODO: replace with real auth logic
+    Navigator.pushNamed(context, '/login');
     return const SizedBox.shrink();
   }
 }

--- a/lib/services/custom_deep_link_service.dart
+++ b/lib/services/custom_deep_link_service.dart
@@ -13,6 +13,8 @@ class CustomDeepLinkService {
   }
   StreamSubscription? _linkSubscription;
   StreamSubscription? _initialLinkSubscription;
+  // GlobalKey is kept for future navigation features.
+  // ignore: unused_field
   GlobalKey<NavigatorState>? _navigatorKey;
 
   /// Set the navigator key for navigation
@@ -114,7 +116,9 @@ class CustomDeepLinkService {
     */
   }
 
-  /// Navigate to meeting details screen
+  // Navigate helper methods are kept for potential future use. They are
+  // commented out to silence analysis warnings.
+  /*
   Future<void> _navigateToMeeting(
     String meetingId,
     String? creatorId,
@@ -132,11 +136,10 @@ class CustomDeepLinkService {
         },
       );
     } else {
-      print('Navigator key not set, cannot navigate to meeting: $meetingId');
+      print('Navigator key not set, cannot navigate to meeting: \$meetingId');
     }
   }
 
-  /// Navigate to invite details screen
   Future<void> _navigateToInvite(String inviteId) async {
     if (_navigatorKey?.currentState != null) {
       _navigatorKey!.currentState!.pushNamed(
@@ -144,11 +147,10 @@ class CustomDeepLinkService {
         arguments: {'inviteId': inviteId},
       );
     } else {
-      print('Navigator key not set, cannot navigate to invite: $inviteId');
+      print('Navigator key not set, cannot navigate to invite: \$inviteId');
     }
   }
 
-  /// Navigate to booking details screen
   Future<void> _navigateToBooking(String bookingId) async {
     if (_navigatorKey?.currentState != null) {
       _navigatorKey!.currentState!.pushNamed(
@@ -156,9 +158,10 @@ class CustomDeepLinkService {
         arguments: {'bookingId': bookingId},
       );
     } else {
-      print('Navigator key not set, cannot navigate to booking: $bookingId');
+      print('Navigator key not set, cannot navigate to booking: \$bookingId');
     }
   }
+  */
 
   /// Create a deep link for a meeting using custom URL scheme
   Future<String> createMeetingLink({

--- a/test/features/personal_app/comments_screen_test.dart
+++ b/test/features/personal_app/comments_screen_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:appoint/extensions/fl_chart_color_shim.dart';
 import 'package:appoint/features/personal_app/ui/comments_screen.dart';
 import '../../fake_firebase_setup.dart';
 


### PR DESCRIPTION
## Summary
- clean up comments screen test imports
- silence unused elements in `CustomDeepLinkService`
- simplify placeholder logic in `AuthWrapper`

## Testing
- `flutter analyze`
- `flutter test --coverage test/features/personal_app/search_screen_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_685ef853d7948324a5adc5fe0f597719