### PR TITLE
Add Notifications screen stub and test

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -27,6 +27,7 @@ import 'package:appoint/features/studio_business/screens/business_profile_screen
 import '../features/invite/invite_list_screen.dart';
 import '../features/personal_app/ui/search_screen.dart';
 import '../features/personal_app/ui/content_detail_screen.dart';
+import '../features/personal_app/ui/notifications_screen.dart';
 
 class AppRouter {
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
@@ -168,6 +169,11 @@ class AppRouter {
       case '/content/:id':
         return MaterialPageRoute(
           builder: (_) => const ContentDetailScreen(),
+          settings: settings,
+        );
+      case '/notifications':
+        return MaterialPageRoute(
+          builder: (_) => const NotificationsScreen(),
           settings: settings,
         );
       case '/search':

--- a/lib/features/personal_app/ui/notifications_screen.dart
+++ b/lib/features/personal_app/ui/notifications_screen.dart
@@ -1,0 +1,20 @@
+// TODO per spec §2.1
+import 'package:flutter/material.dart';
+
+class NotificationsScreen extends StatelessWidget {
+  const NotificationsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Notifications')),
+      body: ListView(
+        children: const [
+          ListTile(title: Text('Notification 1')),
+          ListTile(title: Text('Notification 2')),
+          ListTile(title: Text('Notification 3')),
+        ],
+      ),
+    );
+  }
+}

--- a/test/features/personal_app/notifications_screen_test.dart
+++ b/test/features/personal_app/notifications_screen_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/features/personal_app/ui/notifications_screen.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  group('NotificationsScreen', () {
+    testWidgets('shows 3 placeholder notifications', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: NotificationsScreen(),
+        ),
+      );
+
+      expect(find.byType(ListTile), findsNWidgets(3));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold new `NotificationsScreen`
- register `/notifications` route
- test NotificationsScreen renders 3 ListTile widgets

## Testing
- `flutter analyze`
- `flutter test --coverage test/features/personal_app/notifications_screen_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_685ef8588f5c832485333db459684657