### PR TITLE
Fix conflict in routes by handling content ID

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -166,8 +166,9 @@ class AppRouter {
           settings: settings,
         );
       case '/content/:id':
+        final id = settings.arguments as String? ?? '';
         return MaterialPageRoute(
-          builder: (_) => const ContentDetailScreen(),
+          builder: (_) => ContentDetailScreen(contentId: id),
           settings: settings,
         );
       case '/search':

--- a/lib/features/personal_app/ui/content_detail_screen.dart
+++ b/lib/features/personal_app/ui/content_detail_screen.dart
@@ -2,13 +2,16 @@ import 'package:flutter/material.dart';
 
 /// TODO: Implement detailed content view
 class ContentDetailScreen extends StatelessWidget {
-  const ContentDetailScreen({super.key});
+  final String contentId;
+
+  const ContentDetailScreen({super.key, required this.contentId});
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    return Scaffold(
+      appBar: AppBar(title: const Text('Content Detail')),
       body: Center(
-        child: Text('Content Detail'),
+        child: Text('Content ID: $contentId'),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- pass `contentId` to `ContentDetailScreen` from route
- update `ContentDetailScreen` to display the passed id

## Testing
- `dart test --coverage` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ef98406548324bce4d9aa58e1e350