### PR TITLE
Add SettingsScreen stub and test

### DIFF
--- a/lib/features/personal_app/ui/settings_screen.dart
+++ b/lib/features/personal_app/ui/settings_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+/// Simple stub settings screen for the personal app.
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Settings'),
+      ),
+      body: ListView(
+        children: const [
+          ListTile(
+            title: Text('Notification Preferences'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/features/personal_app/settings_screen_test.dart
+++ b/test/features/personal_app/settings_screen_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/features/personal_app/ui/settings_screen.dart';
+import '../../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  group('SettingsScreen', () {
+    testWidgets('shows notification preference item', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SettingsScreen(),
+        ),
+      );
+
+      expect(find.text('Notification Preferences'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a simple SettingsScreen
- add widget test for SettingsScreen

## Testing
- `flutter analyze --no-pub` *(fails: Unable to 'pub upgrade' flutter tool)*
- `flutter test --coverage test/features/personal_app/settings_screen_test.dart` *(fails: Unable to 'pub upgrade' flutter tool)*

------
https://chatgpt.com/codex/tasks/task_e_685efa4b0fc08324be41702f17243941