### PR TITLE
Fix CI network allowlist and offline pub get

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           echo "PUB_HOSTED_URL=http://localhost:4873" >> $GITHUB_ENV
           echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
-      - run: flutter pub get
+      - run: flutter pub get --offline
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs
       - run: flutter analyze
@@ -103,6 +103,9 @@ jobs:
         run: flutter clean
       - name: Verify Flutter Version
         run: flutter --version
+      - name: Configure Network Allowlist
+        run: |
+          scripts/update_network_allowlist.sh ${{ secrets.GHE_ENTERPRISE }} ${{ secrets.GHE_TOKEN }}
       - name: Pre-flight: Verify network access & Dart
         run: |
           dart --version
@@ -121,7 +124,7 @@ jobs:
         run: |
           echo "PUB_HOSTED_URL=http://localhost:4873" >> $GITHUB_ENV
           echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
-      - run: flutter pub get
+      - run: flutter pub get --offline
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs
       - run: flutter analyze
@@ -153,6 +156,9 @@ jobs:
         run: flutter clean
       - name: Verify Flutter Version
         run: flutter --version
+      - name: Configure Network Allowlist
+        run: |
+          scripts/update_network_allowlist.sh ${{ secrets.GHE_ENTERPRISE }} ${{ secrets.GHE_TOKEN }}
       - name: Pre-flight: Verify network access & Dart
         run: |
           dart --version
@@ -201,6 +207,9 @@ jobs:
         run: flutter clean
       - name: Verify Flutter Version
         run: flutter --version
+      - name: Configure Network Allowlist
+        run: |
+          scripts/update_network_allowlist.sh ${{ secrets.GHE_ENTERPRISE }} ${{ secrets.GHE_TOKEN }}
       - name: Pre-flight: Verify network access & Dart
         run: |
           dart --version
@@ -219,7 +228,7 @@ jobs:
         run: |
           echo "PUB_HOSTED_URL=http://localhost:4873" >> $GITHUB_ENV
           echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
-      - run: flutter pub get
+      - run: flutter pub get --offline
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs
       - run: flutter analyze
@@ -258,6 +267,9 @@ jobs:
         run: flutter clean
       - name: Verify Flutter Version
         run: flutter --version
+      - name: Configure Network Allowlist
+        run: |
+          scripts/update_network_allowlist.sh ${{ secrets.GHE_ENTERPRISE }} ${{ secrets.GHE_TOKEN }}
       - name: Pre-flight: Verify network access & Dart
         run: |
           dart --version
@@ -276,7 +288,7 @@ jobs:
         run: |
           echo "PUB_HOSTED_URL=http://localhost:4873" >> $GITHUB_ENV
           echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
-      - run: flutter pub get
+      - run: flutter pub get --offline
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs
       - run: flutter analyze
@@ -314,6 +326,9 @@ jobs:
         run: flutter clean
       - name: Verify Flutter Version
         run: flutter --version
+      - name: Configure Network Allowlist
+        run: |
+          scripts/update_network_allowlist.sh ${{ secrets.GHE_ENTERPRISE }} ${{ secrets.GHE_TOKEN }}
       - name: Pre-flight: Verify network access & Dart
         run: |
           dart --version
@@ -332,7 +347,7 @@ jobs:
         run: |
           echo "PUB_HOSTED_URL=http://localhost:4873" >> $GITHUB_ENV
           echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
-      - run: flutter pub get
+      - run: flutter pub get --offline
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs
       - run: flutter analyze
@@ -370,6 +385,9 @@ jobs:
         run: flutter clean
       - name: Verify Flutter Version
         run: flutter --version
+      - name: Configure Network Allowlist
+        run: |
+          scripts/update_network_allowlist.sh ${{ secrets.GHE_ENTERPRISE }} ${{ secrets.GHE_TOKEN }}
       - name: Pre-flight: Verify network access & Dart
         run: |
           dart --version
@@ -384,7 +402,7 @@ jobs:
         run: |
           echo "PUB_HOSTED_URL=http://localhost:4873" >> $GITHUB_ENV
           echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
-      - run: flutter pub get
+      - run: flutter pub get --offline
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs
       - run: flutter analyze


### PR DESCRIPTION
## Summary
- ensure each CI job configures the network allowlist before verifying connectivity
- fetch flutter packages in offline mode

## Testing
- `flutter pub get --offline`
- `flutter test --coverage test/playtime/playtime_provider_test.dart` *(fails: PlatformException channel-error)*

------
https://chatgpt.com/codex/tasks/task_e_685f0529fd4c832493b850fd74f41f53