### PR TITLE
Add missing home feed widget test

### DIFF
--- a/test/features/personal_app/comments_screen_test.dart
+++ b/test/features/personal_app/comments_screen_test.dart
@@ -7,7 +7,8 @@ Future<void> main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
   await initializeTestFirebase();
   group('CommentsScreen', () {
-    testWidgets('shows input field and send button', (WidgetTester tester) async {
+    testWidgets('shows input field and send button',
+        (WidgetTester tester) async {
       await tester.pumpWidget(
         const MaterialApp(
           home: CommentsScreen(),

--- a/test/features/personal_app/edit_profile_screen_test.dart
+++ b/test/features/personal_app/edit_profile_screen_test.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/features/personal_app/ui/edit_profile_screen.dart';
+import '../../fake_firebase_setup.dart';
 
 Future<void> main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
   group('EditProfileScreen', () {
     testWidgets('renders form fields and save button', (tester) async {
       await tester.pumpWidget(const MaterialApp(home: EditProfileScreen()));

--- a/test/features/personal_app/home_feed_screen_test.dart
+++ b/test/features/personal_app/home_feed_screen_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/features/personal_app/home_feed_screen.dart';
+import '../../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  group('HomeFeedScreen', () {
+    testWidgets('shows placeholder feed text', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: HomeFeedScreen()));
+
+      expect(find.text('Home Feed Screen'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/personal_app/notifications_screen_test.dart
+++ b/test/features/personal_app/notifications_screen_test.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/features/personal_app/ui/notifications_screen.dart';
+import '../../fake_firebase_setup.dart';
 
 Future<void> main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
   group('NotificationsScreen', () {
     testWidgets('shows 3 placeholder notifications', (tester) async {
       await tester.pumpWidget(

--- a/test/features/personal_app/profile_screen_test.dart
+++ b/test/features/personal_app/profile_screen_test.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/features/personal_app/ui/profile_screen.dart';
+import '../../fake_firebase_setup.dart';
 
 Future<void> main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
   group('ProfileScreen', () {
     testWidgets('renders avatar, text, and edit button', (tester) async {
       await tester.pumpWidget(const MaterialApp(home: ProfileScreen()));

--- a/test/features/personal_app/settings_screen_test.dart
+++ b/test/features/personal_app/settings_screen_test.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appoint/features/personal_app/ui/settings_screen.dart';
+import '../../fake_firebase_setup.dart';
 
 Future<void> main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
   group('SettingsScreen', () {
     testWidgets('shows settings text', (WidgetTester tester) async {
       await tester.pumpWidget(const MaterialApp(home: SettingsScreen()));


### PR DESCRIPTION
## Summary
- create HomeFeedScreen widget test
- initialize Firebase mocks in all personal app widget tests

## Testing
- `flutter test test/features/personal_app/home_feed_screen_test.dart test/features/personal_app/profile_screen_test.dart test/features/personal_app/edit_profile_screen_test.dart test/features/personal_app/notifications_screen_test.dart test/features/personal_app/settings_screen_test.dart test/features/personal_app/search_screen_test.dart test/features/personal_app/comments_screen_test.dart`
- `flutter test --coverage` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_685f072c6080832486b9a8818083ab7e