### PR TITLE
Ensure storage.googleapis.com allowed in CI

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -29,6 +29,9 @@ jobs:
         run: flutter clean
       - name: Verify Flutter Version
         run: flutter --version
+      - name: Configure Network Allowlist
+        run: |
+          scripts/update_network_allowlist.sh ${{ secrets.GHE_ENTERPRISE }} ${{ secrets.GHE_TOKEN }}
       - name: "Pre-flight: Verify network & Dart"
         run: |
           dart --version

--- a/.github/workflows/flutter_web.yml
+++ b/.github/workflows/flutter_web.yml
@@ -29,6 +29,9 @@ jobs:
       run: flutter clean
     - name: Verify Flutter Version
       run: flutter --version
+    - name: Configure Network Allowlist
+      run: |
+        scripts/update_network_allowlist.sh ${{ secrets.GHE_ENTERPRISE }} ${{ secrets.GHE_TOKEN }}
     - name: "Pre-flight: Verify network & Dart"
       run: |
         dart --version

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -29,6 +29,9 @@ jobs:
         run: flutter clean
       - name: Verify Flutter Version
         run: flutter --version
+      - name: Configure Network Allowlist
+        run: |
+          scripts/update_network_allowlist.sh ${{ secrets.GHE_ENTERPRISE }} ${{ secrets.GHE_TOKEN }}
       - name: "Pre-flight: Verify network & Dart"
         run: |
           dart --version


### PR DESCRIPTION
## Summary
- include `scripts/update_network_allowlist.sh` step in all CI workflows

## Testing
- `dart test --coverage` *(fails: Flutter SDK version solving)*
- `firebase emulators:start --only auth,firestore` *(fails: download failed, status 403)*

------
https://chatgpt.com/codex/tasks/task_e_685f0a1f48a48324a4ae451899324251