### PR TITLE
Fix playtime provider tests

### DIFF
--- a/test/playtime/playtime_provider_test.dart
+++ b/test/playtime/playtime_provider_test.dart
@@ -16,7 +16,13 @@ Future<void> main() async {
     late ProviderContainer container;
 
     setUp(() {
-      container = ProviderContainer();
+      container = ProviderContainer(overrides: [
+        allGamesProvider.overrideWith((ref) => Stream.value(<PlaytimeGame>[])),
+        allSessionsProvider.overrideWith(
+            (ref) => Stream.value(<PlaytimeSession>[])),
+        allBackgroundsProvider.overrideWith(
+            (ref) => Stream.value(<PlaytimeBackground>[])),
+      ]);
     });
 
     tearDown(() {


### PR DESCRIPTION
## Summary
- mock Playtime stream providers in tests to avoid Firebase channel issues

## Testing
- `flutter pub get --offline`
- `flutter test --coverage test/playtime/playtime_provider_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_685f0a1659c083248aecc1bdacd75894