### PR TITLE
Add admin dashboard UI

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -11,7 +11,7 @@ import '../features/dashboard/dashboard_screen.dart';
 import '../features/personal_app/ui/profile_screen.dart';
 import '../features/personal_app/ui/edit_profile_screen.dart';
 import '../features/personal_app/ui/settings_screen.dart';
-import '../features/admin/admin_dashboard_screen.dart';
+import '../features/admin/ui/admin_dashboard_screen.dart';
 import '../features/family/widgets/invitation_modal.dart';
 import '../features/family/screens/family_dashboard_screen.dart';
 import '../features/family/screens/invite_child_screen.dart';

--- a/lib/features/admin/ui/admin_dashboard_screen.dart
+++ b/lib/features/admin/ui/admin_dashboard_screen.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class AdminDashboardScreen extends ConsumerWidget {
+  const AdminDashboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Admin Dashboard')),
+      body: const Center(child: Text('Admin overview goes here')),
+    );
+  }
+}

--- a/test/features/admin/admin_dashboard_screen_test.dart
+++ b/test/features/admin/admin_dashboard_screen_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:appoint/features/admin/ui/admin_dashboard_screen.dart';
+import '../../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  testWidgets('Admin Dashboard shows overview text', (WidgetTester tester) async {
+    await tester.pumpWidget(const ProviderScope(
+      child: MaterialApp(home: AdminDashboardScreen()),
+    ));
+
+    expect(find.text('Admin overview goes here'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add minimal AdminDashboardScreen widget under admin/ui
- wire up `/admin/dashboard` route to new screen location
- test admin dashboard screen

## Testing
- `flutter analyze`
- `flutter test --coverage test/features/admin/admin_dashboard_screen_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_685f0b69a7548324bf1f79cec58d525a