### PR TITLE
Add parental consent prompt

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -16,6 +16,7 @@ import '../features/family/widgets/invitation_modal.dart';
 import '../features/family/screens/family_dashboard_screen.dart';
 import '../features/family/screens/invite_child_screen.dart';
 import '../features/family/screens/permissions_screen.dart';
+import '../features/family/ui/parental_consent_prompt.dart';
 import '../features/invite/invite_detail_screen.dart';
 import '../features/booking/booking_confirm_screen.dart';
 import '../features/admin/admin_broadcast_screen.dart';
@@ -102,6 +103,11 @@ class AppRouter {
       case '/family/invite-child':
         return MaterialPageRoute(
           builder: (_) => const InviteChildScreen(),
+          settings: settings,
+        );
+      case '/parental-consent':
+        return MaterialPageRoute(
+          builder: (_) => const ParentalConsentPrompt(),
           settings: settings,
         );
       case '/family/permissions':

--- a/lib/features/family/ui/parental_consent_prompt.dart
+++ b/lib/features/family/ui/parental_consent_prompt.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+/// Simple screen prompting for parental consent with affirmative and decline actions.
+class ParentalConsentPrompt extends StatelessWidget {
+  const ParentalConsentPrompt({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Parental Consent'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              'Parental Consent Required',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'We need your consent to proceed. Please review the information and select an option below.',
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: () {},
+              child: const Text('I Consent'),
+            ),
+            const SizedBox(height: 8),
+            OutlinedButton(
+              onPressed: () {},
+              child: const Text('I Do Not Consent'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/family/parental_consent_prompt_test.dart
+++ b/test/features/family/parental_consent_prompt_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/features/family/ui/parental_consent_prompt.dart';
+import '../../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  group('ParentalConsentPrompt', () {
+    testWidgets('shows both consent buttons', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: ParentalConsentPrompt()));
+
+      expect(find.text('I Consent'), findsOneWidget);
+      expect(find.text('I Do Not Consent'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- create parental consent prompt screen
- register screen in routes
- test for consent buttons

## Testing
- `flutter analyze` *(fails: The current Flutter SDK version is 0.0.0-unknown)*
- `flutter test --coverage test/features/family/parental_consent_prompt_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_685f0b70dcdc8324901a311d9cf354f3