### PR TITLE
Resolve merge markers in test setup

### DIFF
--- a/test/test_setup.dart
+++ b/test/test_setup.dart
@@ -1,3 +1,4 @@
+// Centralized utilities for initializing and mocking Firebase during tests.
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:appoint/firebase_options.dart';


### PR DESCRIPTION
## Summary
- document Firebase mocking utilities in test setup

## Testing
- `flutter analyze`
- `test/test_setup_test.dart` does not exist

------
https://chatgpt.com/codex/tasks/task_e_685f0cd31ae883248c39ab7bf729c848