### PR TITLE
Add Studio Dashboard screen with routing and tests

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -5,6 +5,7 @@ import '../features/auth/home_screen.dart';
 import '../features/studio/studio_booking_screen.dart';
 import '../features/studio/studio_booking_confirm_screen.dart';
 import '../features/studio/ui/content_library_screen.dart';
+import '../features/studio/ui/studio_dashboard_screen.dart';
 import '../features/booking/screens/chat_booking_screen.dart';
 import '../features/booking/booking_request_screen.dart';
 import '../features/dashboard/dashboard_screen.dart';
@@ -47,6 +48,11 @@ class AppRouter {
       case '/studio/confirm':
         return MaterialPageRoute(
           builder: (_) => const StudioBookingConfirmScreen(),
+          settings: settings,
+        );
+      case '/studio/dashboard':
+        return MaterialPageRoute(
+          builder: (_) => const StudioDashboardScreen(),
           settings: settings,
         );
       case '/studio/library':

--- a/lib/features/studio/ui/studio_dashboard_screen.dart
+++ b/lib/features/studio/ui/studio_dashboard_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder dashboard for creator studio
+class StudioDashboardScreen extends StatelessWidget {
+  const StudioDashboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Studio Dashboard'),
+      ),
+      body: const Center(
+        child: Text('Welcome to your studio'),
+      ),
+    );
+  }
+}

--- a/test/features/studio/studio_dashboard_screen_test.dart
+++ b/test/features/studio/studio_dashboard_screen_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/features/studio/ui/studio_dashboard_screen.dart';
+import '../../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+  group('StudioDashboardScreen', () {
+    testWidgets('shows welcome text', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: StudioDashboardScreen(),
+        ),
+      );
+
+      expect(find.text('Welcome to your studio'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold Studio Dashboard screen in `lib/features/studio/ui/studio_dashboard_screen.dart`
- route `/studio/dashboard` to the new screen
- test screen renders placeholder welcome text

## Testing
- `../flutter_sdk/bin/flutter analyze`
- `../flutter_sdk/bin/flutter test --coverage test/features/studio/studio_dashboard_screen_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_685f0b603c348324b571506fae0f4641