### PR TITLE
Fix network allowlist script and emulator install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Pre-flight: Verify network access & Dart
         run: |
           dart --version
-          for host in pub.dev storage.googleapis.com; do
+          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
       - name: Set up Node.js
@@ -71,9 +71,7 @@ jobs:
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
       - name: Download Firebase emulators
-        run: |
-          firebase setup:emulators:firestore
-          firebase setup:emulators:auth
+        run: firebase setup:emulators:download --only firestore,auth
       - name: Start Firebase emulators
         run: |
           firebase emulators:start --only auth,firestore &
@@ -117,7 +115,7 @@ jobs:
       - name: Pre-flight: Verify network access & Dart
         run: |
           dart --version
-          for host in pub.dev storage.googleapis.com; do
+          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
       - name: Set up Node.js
@@ -172,7 +170,7 @@ jobs:
       - name: Pre-flight: Verify network access & Dart
         run: |
           dart --version
-          for host in pub.dev storage.googleapis.com; do
+          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
       - name: Set up Node.js
@@ -225,7 +223,7 @@ jobs:
       - name: Pre-flight: Verify network access & Dart
         run: |
           dart --version
-          for host in pub.dev storage.googleapis.com; do
+          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
       - name: Set up Node.js
@@ -287,7 +285,7 @@ jobs:
       - name: Pre-flight: Verify network access & Dart
         run: |
           dart --version
-          for host in pub.dev storage.googleapis.com; do
+          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
       - name: Set up Node.js
@@ -348,7 +346,7 @@ jobs:
       - name: Pre-flight: Verify network access & Dart
         run: |
           dart --version
-          for host in pub.dev storage.googleapis.com; do
+          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
       - name: Set up Node.js
@@ -409,7 +407,7 @@ jobs:
       - name: Pre-flight: Verify network access & Dart
         run: |
           dart --version
-          for host in pub.dev storage.googleapis.com; do
+          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
       - name: Install Verdaccio

--- a/scripts/update_network_allowlist.sh
+++ b/scripts/update_network_allowlist.sh
@@ -12,7 +12,7 @@ if [[ -z "$ENTERPRISE" || -z "$TOKEN" ]]; then
   exit 1
 fi
 
-BODY='{"domains":["storage.googleapis.com","pub.dev"]}'
+BODY='{"domains":["storage.googleapis.com","pub.dev","firebase-public.firebaseio.com","metadata.google.internal","169.254.169.254"]}'
 
 curl -sSL -X PUT \
   -H "Authorization: Bearer ${TOKEN}" \


### PR DESCRIPTION
## Summary
- expand allowed domains in update_network_allowlist.sh
- use `firebase setup:emulators:download` in CI
- verify more hosts during network pre-flight

## Testing
- `scripts/update_network_allowlist.sh foo bar` *(fails: Bad credentials)*
- `firebase setup:emulators:download firestore` *(fails: command not found)*
- `firebase emulators:start --only firestore,auth` *(fails: Request failed with status code 403)*
- `dart test --coverage` *(fails: missing argument)*

------
https://chatgpt.com/codex/tasks/task_e_685f0df2ca4483248f4daa957e9ccad0