### PR TITLE
Lock Flutter action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Fetch tags
         run: git fetch --tags
       - name: Setup Flutter SDK
-        uses: flutter-actions/setup-flutter@v2
+        uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.20.0'
       - name: Cache Pub packages
@@ -95,7 +95,7 @@ jobs:
       - name: Fetch tags
         run: git fetch --tags
       - name: Setup Flutter SDK
-        uses: flutter-actions/setup-flutter@v2
+        uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.20.0'
       - name: Cache Pub packages
@@ -150,7 +150,7 @@ jobs:
       - name: Fetch tags
         run: git fetch --tags
       - name: Setup Flutter SDK
-        uses: flutter-actions/setup-flutter@v2
+        uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.20.0'
       - name: Cache Pub packages
@@ -203,7 +203,7 @@ jobs:
       - name: Fetch tags
         run: git fetch --tags
       - name: Setup Flutter SDK
-        uses: flutter-actions/setup-flutter@v2
+        uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.20.0'
       - name: Cache Pub packages
@@ -265,7 +265,7 @@ jobs:
       - name: Fetch tags
         run: git fetch --tags
       - name: Setup Flutter SDK
-        uses: flutter-actions/setup-flutter@v2
+        uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.20.0'
       - name: Cache Pub packages
@@ -326,7 +326,7 @@ jobs:
       - name: Fetch tags
         run: git fetch --tags
       - name: Setup Flutter SDK
-        uses: flutter-actions/setup-flutter@v2
+        uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.20.0'
       - name: Cache Pub packages
@@ -387,7 +387,7 @@ jobs:
       - name: Fetch tags
         run: git fetch --tags
       - name: Setup Flutter SDK
-        uses: flutter-actions/setup-flutter@v2
+        uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.20.0'
       - name: Cache Pub packages


### PR DESCRIPTION
## Summary
- lock Flutter version in CI using `subosito/flutter-action`

## Testing
- `flutter pub get --offline`
- `flutter analyze`


------
https://chatgpt.com/codex/tasks/task_e_685f0e9222448324bd24d1092bc63dba