### PR TITLE
Resolve merge conflict in test_setup

### DIFF
--- a/test/test_setup.dart
+++ b/test/test_setup.dart
@@ -1,4 +1,5 @@
-// Centralized utilities for initializing and mocking Firebase during tests.
+// Test utilities for initializing Firebase and mocking plugins.
+// Call [registerFirebaseMock] in your tests to prevent platform channel errors.
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:appoint/firebase_options.dart';

--- a/test/test_setup_test.dart
+++ b/test/test_setup_test.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'test_setup.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  test('setup loads without error', () async {
+    await registerFirebaseMock();
+    expect(true, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- update `test_setup.dart` header comment
- add a regression test to ensure the firebase test utilities load

## Testing
- `flutter analyze`
- `flutter test test/test_setup_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_685f107a0f588324a4e0ab73e38b361a