### PR TITLE
fix(ci): expose dart CLI in path to support dart test coverage run

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -20,8 +20,10 @@ jobs:
         uses: flutter-actions/setup-flutter@v2
         with:
           flutter-version: '3.20.0'
-      - name: Ensure flutter in PATH
-        run: echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+      - name: Ensure Flutter & Dart in PATH
+        run: |
+          echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+          echo "$HOME/.flutter/bin/cache/dart-sdk/bin" >> $GITHUB_PATH
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:
@@ -51,7 +53,14 @@ jobs:
         run: flutter pub get --offline
       - run: flutter analyze
       - run: dart analyze
-      - run: flutter test --coverage test/
+      - name: Run tests with coverage
+        run: |
+          if command -v dart >/dev/null 2>&1; then
+            dart test --coverage
+          else
+            echo "::warning::dart CLI not found; using flutter" >&2
+            flutter test --coverage
+          fi
       - run: dart test integration_test/
       - run: flutter build web
       - uses: codecov/codecov-action@v3

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -4,21 +4,34 @@ MODE="$1"
 
 case "$MODE" in
   unit)
-    flutter test
+    if command -v dart >/dev/null 2>&1; then
+      dart test --coverage
+    else
+      flutter test --coverage
+    fi
     ;;
   integration)
     npx firebase emulators:start --only firestore,functions --project "$FIREBASE_PROJECT" --import=./emulator_data &
     EMULATOR_PID=$!
     sleep 5
-    flutter test integration_test/app_test.dart
+    if command -v dart >/dev/null 2>&1; then
+      dart test integration_test/app_test.dart
+    else
+      flutter test integration_test/app_test.dart
+    fi
     kill $EMULATOR_PID
     ;;
   all|*)
     npx firebase emulators:start --only firestore,functions --project "$FIREBASE_PROJECT" --import=./emulator_data &
     EMULATOR_PID=$!
     sleep 5
-    flutter test
-    flutter test integration_test/app_test.dart
+    if command -v dart >/dev/null 2>&1; then
+      dart test --coverage
+      dart test integration_test/app_test.dart
+    else
+      flutter test --coverage
+      flutter test integration_test/app_test.dart
+    fi
     kill $EMULATOR_PID
     ;;
 esac


### PR DESCRIPTION
## Summary
- expose Dart from the Flutter SDK in PATH
- prefer `dart test --coverage` when available
- fall back to `flutter test --coverage`

## Testing
- `dart test --coverage` *(fails: The current Flutter SDK version is 0.0.0-unknown)*
- `flutter test --coverage` *(fails to resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685f123c1b8c8324b755d6c1d19f48cf