### PR TITLE
Fix Firebase test setup

### DIFF
--- a/test/test_setup.dart
+++ b/test/test_setup.dart
@@ -1,43 +1,37 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'package:firebase_auth_platform_interface/firebase_auth_platform_interface.dart';
-import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
-import 'package:firebase_crashlytics_platform_interface/firebase_crashlytics_platform_interface.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:file_picker/file_picker.dart';
 
 import '../lib/generated/pigeon_auth_api.dart';
 import '../lib/generated/pigeon_firestore_api.dart';
 
-class MockFirebaseAuthPlatform extends Mock implements FirebaseAuthPlatform {}
-class MockFirebaseFirestorePlatform extends Mock implements FirebaseFirestorePlatform {}
-class MockFirebaseCrashlyticsPlatform extends Mock implements FirebaseCrashlyticsPlatform {}
+// Mocks
+class MockFirebaseAuth extends Mock implements FirebaseAuth {}
+class MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
+class MockFirebaseCrashlytics extends Mock implements FirebaseCrashlytics {}
+class MockFirebaseAppCheck extends Mock implements FirebaseAppCheck {}
 class MockFilePicker extends Mock implements FilePicker {}
+class MockAuthHostApi extends Mock implements AuthHostApi {}
+class MockFirestoreHostApi extends Mock implements FirestoreHostApi {}
 
-void setupFirebaseMocks() {
+void setupFirebaseTestMocks() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() async {
     await Firebase.initializeApp();
 
-    FirebaseAuthPlatform.instance = MockFirebaseAuthPlatform();
-    FirebaseFirestorePlatform.instance = MockFirebaseFirestorePlatform();
-    FirebaseCrashlyticsPlatform.instance = MockFirebaseCrashlyticsPlatform();
+    FirebaseAuth.instanceFor = ({required FirebaseApp app}) => MockFirebaseAuth();
+    FirebaseFirestore.instanceFor = ({required FirebaseApp app}) => MockFirebaseFirestore();
+    FirebaseCrashlytics.instance = MockFirebaseCrashlytics();
+    FirebaseAppCheck.instance = MockFirebaseAppCheck();
     FilePicker.platform = MockFilePicker();
 
     AuthHostApi.setup(MockAuthHostApi());
     FirestoreHostApi.setup(MockFirestoreHostApi());
   });
 }
-
-void main() {
-  setupFirebaseMocks();
-
-  test('Firebase test setup initializes without error', () {
-    expect(() => FirebaseAuthPlatform.instance, returnsNormally);
-    expect(() => FirebaseFirestorePlatform.instance, returnsNormally);
-  });
-}
-
-class MockAuthHostApi extends Mock implements AuthHostApi {}
-class MockFirestoreHostApi extends Mock implements FirestoreHostApi {}


### PR DESCRIPTION
## Summary
- restore centralized Firebase mocks for widget tests

## Testing
- `flutter --version`
- `flutter test --coverage` *(fails: package resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_685fb60a4c248324931d255e2c22e0bd