### PR TITLE
Add EditProfileScreen for profile editing

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -11,6 +11,7 @@ import '../features/booking/booking_request_screen.dart';
 import '../features/dashboard/dashboard_screen.dart';
 import '../features/personal_app/ui/profile_screen.dart';
 import '../features/personal_app/ui/edit_profile_screen.dart';
+import '../features/profile/ui/edit_profile_screen.dart' as profile_edit;
 import '../features/personal_app/ui/settings_screen.dart';
 import '../features/admin/ui/admin_dashboard_screen.dart';
 import '../features/family/widgets/invitation_modal.dart';
@@ -84,6 +85,11 @@ class AppRouter {
       case '/profile/edit':
         return MaterialPageRoute(
           builder: (_) => const EditProfileScreen(),
+          settings: settings,
+        );
+      case '/edit-profile':
+        return MaterialPageRoute(
+          builder: (_) => const profile_edit.EditProfileScreen(),
           settings: settings,
         );
       case '/settings':

--- a/lib/features/profile/ui/edit_profile_screen.dart
+++ b/lib/features/profile/ui/edit_profile_screen.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+class EditProfileScreen extends StatefulWidget {
+  const EditProfileScreen({super.key});
+
+  @override
+  State<EditProfileScreen> createState() => _EditProfileScreenState();
+}
+
+class _EditProfileScreenState extends State<EditProfileScreen> {
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _bioController = TextEditingController();
+  final TextEditingController _locationController = TextEditingController();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _bioController.dispose();
+    _locationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Edit Profile'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Name'),
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _bioController,
+              decoration: const InputDecoration(labelText: 'Bio'),
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _locationController,
+              decoration: const InputDecoration(labelText: 'Location'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: null,
+              child: const Text('Save Changes'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/profile/edit_profile_screen_test.dart
+++ b/test/features/profile/edit_profile_screen_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/features/profile/ui/edit_profile_screen.dart';
+import '../../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+  group('EditProfileScreen', () {
+    testWidgets('shows app bar and form fields', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: EditProfileScreen()));
+
+      expect(find.text('Edit Profile'), findsOneWidget);
+      expect(find.byType(TextField), findsNWidgets(3));
+      expect(find.text('Name'), findsOneWidget);
+      expect(find.text('Bio'), findsOneWidget);
+      expect(find.text('Location'), findsOneWidget);
+      expect(find.text('Save Changes'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add EditProfileScreen UI in profile feature
- wire /edit-profile route in AppRouter
- test EditProfileScreen widget

## Testing
- `flutter test --coverage` *(fails: PlatformException unable to establish connection)*

------
https://chatgpt.com/codex/tasks/task_e_685fb6b717a88324a633c10012c3ed5b