### PR TITLE
🔄 Add reusable LoadingSpinner widget with tests

### DIFF
--- a/lib/components/common/loading_spinner.dart
+++ b/lib/components/common/loading_spinner.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+/// Simple centered loading spinner with optional text.
+class LoadingSpinner extends StatelessWidget {
+  /// Message shown below the spinner.
+  final String text;
+
+  const LoadingSpinner({super.key, this.text = 'Loading...'});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const CircularProgressIndicator(),
+          const SizedBox(height: 16),
+          Text(text),
+        ],
+      ),
+    );
+  }
+}

--- a/test/components/common/loading_spinner_test.dart
+++ b/test/components/common/loading_spinner_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/components/common/loading_spinner.dart';
+import '../../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  group('LoadingSpinner', () {
+    testWidgets('shows default text', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: LoadingSpinner(),
+        ),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('Loading...'), findsOneWidget);
+    });
+
+    testWidgets('shows custom text', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: LoadingSpinner(text: 'Please wait'),
+        ),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('Please wait'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `LoadingSpinner` widget under `components/common`
- cover default and custom text in widget tests

## Testing
- `flutter pub get` *(fails: command not found or due to repo ownership)*
- `flutter test --coverage test/components/common/loading_spinner_test.dart` *(fails: PlatformException channel-error)*

------
https://chatgpt.com/codex/tasks/task_e_685fb6c031048324a4fe6390a7afec17