### PR TITLE
🛑 Add ErrorScreen scaffold and routing

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -33,5 +33,6 @@ The app uses `onGenerateRoute` in `lib/config/routes.dart` to map named routes t
 | `/content/:id` | `ContentDetailScreen` (expects content ID argument) |
 | `/notifications` | `NotificationsScreen` |
 | `/search` | `SearchScreen` |
+| `/error` | `ErrorScreen` |
 
 Unrecognized routes fall back to a simple screen explaining that no matching route was found. Ensure `onGenerateRoute` stays conflict-free and that each screen imports correctly.

--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -32,6 +32,7 @@ import '../features/invite/invite_list_screen.dart';
 import '../features/personal_app/ui/search_screen.dart';
 import '../features/personal_app/ui/content_detail_screen.dart';
 import '../features/personal_app/ui/notifications_screen.dart';
+import '../features/common/ui/error_screen.dart';
 
 class AppRouter {
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
@@ -199,6 +200,15 @@ class AppRouter {
       case '/search':
         return MaterialPageRoute(
           builder: (_) => const SearchScreen(),
+          settings: settings,
+        );
+      case '/error':
+        final args = settings.arguments as Map<String, dynamic>? ?? {};
+        return MaterialPageRoute(
+          builder: (_) => ErrorScreen(
+            message: args['message'] as String? ?? 'An error occurred',
+            onTryAgain: args['onTryAgain'] as VoidCallback? ?? () {},
+          ),
           settings: settings,
         );
       default:

--- a/lib/features/common/ui/error_screen.dart
+++ b/lib/features/common/ui/error_screen.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+/// Simple error screen with retry action.
+class ErrorScreen extends StatelessWidget {
+  final String message;
+  final VoidCallback onTryAgain;
+
+  const ErrorScreen({
+    Key? key,
+    required this.message,
+    required this.onTryAgain,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.error_outline,
+              size: 96,
+              color: Colors.red,
+            ),
+            const SizedBox(height: 24),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: onTryAgain,
+              child: const Text('Try Again'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/common/ui/error_screen_test.dart
+++ b/test/features/common/ui/error_screen_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/features/common/ui/error_screen.dart';
+import '../../../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  group('ErrorScreen (features)', () {
+    testWidgets('renders icon, message and try again button', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ErrorScreen(
+            message: 'Oops',
+            onTryAgain: () {},
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      expect(find.text('Oops'), findsOneWidget);
+      expect(find.text('Try Again'), findsOneWidget);
+      expect(find.byType(ElevatedButton), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a new ErrorScreen under `features/common`
- map `/error` route to ErrorScreen in AppRouter
- document the new route
- add widget test for ErrorScreen

## Testing
- `firebase emulators:start --only auth,firestore` *(fails: command not found)*
- `dart test --coverage=coverage` *(fails: some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_685fb6c81c9c832497fe95a7297e93b0