### PR TITLE
Add centralized AppColors theme

### DIFF
--- a/lib/config/theme.dart
+++ b/lib/config/theme.dart
@@ -1,27 +1,32 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 
 class AppTheme {
-  // Color constants
-  static const Color primaryColor = Colors.deepPurple;
-  static const Color secondaryColor = Colors.blue;
+  // Color constants centralized in [AppColors]
+  static const Color primaryColor = AppColors.primary;
+  static const Color secondaryColor = AppColors.secondary;
   static const Color accentColor = Colors.orange;
-  static const Color backgroundColor = Colors.white;
+  static const Color backgroundColor = AppColors.background;
   static const Color surfaceColor = Colors.grey;
-  static const Color errorColor = Colors.red;
+  static const Color errorColor = AppColors.error;
 
   static final ThemeData lightTheme = ThemeData(
     useMaterial3: true,
-    colorScheme: ColorScheme.fromSeed(
-      seedColor: primaryColor,
-      brightness: Brightness.light,
+    colorScheme: const ColorScheme.light(
+      primary: AppColors.primary,
+      secondary: AppColors.secondary,
+      background: AppColors.background,
+      error: AppColors.error,
     ),
   );
 
   static final ThemeData darkTheme = ThemeData(
     useMaterial3: true,
-    colorScheme: ColorScheme.fromSeed(
-      seedColor: primaryColor,
-      brightness: Brightness.dark,
+    colorScheme: const ColorScheme.dark(
+      primary: AppColors.primary,
+      secondary: AppColors.secondary,
+      background: AppColors.background,
+      error: AppColors.error,
     ),
   );
 }

--- a/lib/features/auth/home_screen.dart
+++ b/lib/features/auth/home_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../providers/auth_provider.dart';
 import '../../providers/appointment_provider.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import '../../theme/app_colors.dart';
 
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({Key? key}) : super(key: key);
@@ -12,6 +13,7 @@ class HomeScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final appointments = ref.watch(appointmentsStreamProvider);
     return Scaffold(
+      backgroundColor: AppColors.primary,
       appBar: AppBar(title: const Text('Home')),
       drawer: const _HomeDrawer(),
       body: Center(
@@ -98,10 +100,9 @@ class _HomeDrawer extends ConsumerWidget {
             },
           ),
           FutureBuilder<bool>(
-            future: FirebaseAuth.instance
-                .currentUser
-                ?.getIdTokenResult(true)
-                .then((r) => r.claims?['admin'] == true) ??
+            future: FirebaseAuth.instance.currentUser
+                    ?.getIdTokenResult(true)
+                    .then((r) => r.claims?['admin'] == true) ??
                 Future.value(false),
             builder: (context, snapshot) {
               if (snapshot.data == true) {

--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+class AppColors {
+  static const Color primary = Color(0xFF1E88E5);
+  static const Color secondary = Color(0xFF42A5F5);
+  static const Color background = Color(0xFFF1F1F1);
+  static const Color error = Colors.red;
+}


### PR DESCRIPTION
## Summary
- add `AppColors` with shared color constants
- use `AppColors` in `AppTheme`
- set `HomeScreen` background color to `AppColors.primary`

## Testing
- `flutter pub get`
- `dart test --coverage=coverage` *(fails: Failed to load tests)*

------
https://chatgpt.com/codex/tasks/task_e_685fb6d2b4588324a0e9c53b91ac41dc