### PR TITLE
Add Parental Settings screen

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -18,6 +18,7 @@ import '../features/family/screens/family_dashboard_screen.dart';
 import '../features/family/screens/invite_child_screen.dart';
 import '../features/family/screens/permissions_screen.dart';
 import '../features/family/ui/parental_consent_prompt.dart';
+import '../features/family/ui/parental_settings_screen.dart';
 import '../features/invite/invite_detail_screen.dart';
 import '../features/booking/booking_confirm_screen.dart';
 import '../features/admin/admin_broadcast_screen.dart';
@@ -114,6 +115,11 @@ class AppRouter {
       case '/parental-consent':
         return MaterialPageRoute(
           builder: (_) => const ParentalConsentPrompt(),
+          settings: settings,
+        );
+      case '/parental-settings':
+        return MaterialPageRoute(
+          builder: (_) => const ParentalSettingsScreen(),
           settings: settings,
         );
       case '/family/permissions':

--- a/lib/features/family/ui/parental_settings_screen.dart
+++ b/lib/features/family/ui/parental_settings_screen.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+/// Screen allowing parents to manage basic parental controls.
+class ParentalSettingsScreen extends StatefulWidget {
+  const ParentalSettingsScreen({super.key});
+
+  @override
+  State<ParentalSettingsScreen> createState() => _ParentalSettingsScreenState();
+}
+
+class _ParentalSettingsScreenState extends State<ParentalSettingsScreen> {
+  bool _restrictMatureContent = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Parental Settings'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SwitchListTile(
+              title: const Text('Restrict mature content'),
+              value: _restrictMatureContent,
+              onChanged: (value) {
+                setState(() {
+                  _restrictMatureContent = value;
+                });
+              },
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {},
+              child: const Text('Manage Child Accounts'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/family/parental_settings_screen_test.dart
+++ b/test/features/family/parental_settings_screen_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/features/family/ui/parental_settings_screen.dart';
+import '../../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  group('ParentalSettingsScreen', () {
+    testWidgets('shows toggle and manage accounts button', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: ParentalSettingsScreen()),
+      );
+
+      expect(find.text('Restrict mature content'), findsOneWidget);
+      expect(find.text('Manage Child Accounts'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold basic parental settings UI
- map `/parental-settings` route in `AppRouter`
- test widget for toggle and button

## Testing
- `flutter pub get`
- `dart test --coverage=coverage` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685fb6db0d1083248b681950a3ce66a0