### PR TITLE
Add dart CLI fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,15 @@ jobs:
           (firebase emulators:start --only firestore,auth || sleep 5 && firebase emulators:start --only firestore,auth) &
           echo $! > emulator.pid
       - run: flutter pub downgrade || true
-      - run: flutter test --coverage
-      - run: dart test --coverage
+      - name: Run tests with coverage
+        run: |
+          if which dart >/dev/null 2>&1; then
+            echo "Using Dart at $(which dart)"
+            dart test --coverage
+          else
+            echo "::warning::dart CLI not found; using flutter" >&2
+            flutter test --coverage
+          fi
       - run: dart test integration_test/
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3
@@ -157,7 +164,15 @@ jobs:
       - run: flutter analyze
       - run: dart analyze
       - run: flutter pub downgrade || true
-      - run: flutter test --coverage test/features/studio/content_library_screen_test.dart
+      - name: Run content library test with coverage
+        run: |
+          if which dart >/dev/null 2>&1; then
+            echo "Using Dart at $(which dart)"
+            dart test --coverage test/features/studio/content_library_screen_test.dart
+          else
+            echo "::warning::dart CLI not found; using flutter" >&2
+            flutter test --coverage test/features/studio/content_library_screen_test.dart
+          fi
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3
         with:
@@ -277,8 +292,15 @@ jobs:
       - run: flutter analyze
       - run: dart analyze
       - run: flutter pub downgrade || true
-      - run: flutter test --coverage
-      - run: dart test --coverage
+      - name: Run tests with coverage
+        run: |
+          if which dart >/dev/null 2>&1; then
+            echo "Using Dart at $(which dart)"
+            dart test --coverage
+          else
+            echo "::warning::dart CLI not found; using flutter" >&2
+            flutter test --coverage
+          fi
       - run: dart test integration_test/
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3
@@ -349,8 +371,15 @@ jobs:
       - run: flutter analyze
       - run: dart analyze
       - run: flutter pub downgrade || true
-      - run: flutter test --coverage
-      - run: dart test --coverage
+      - name: Run tests with coverage
+        run: |
+          if which dart >/dev/null 2>&1; then
+            echo "Using Dart at $(which dart)"
+            dart test --coverage
+          else
+            echo "::warning::dart CLI not found; using flutter" >&2
+            flutter test --coverage
+          fi
       - run: dart test integration_test/
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3
@@ -420,8 +449,15 @@ jobs:
       - run: flutter analyze
       - run: dart analyze
       - run: flutter pub downgrade || true
-      - run: flutter test --coverage
-      - run: dart test --coverage
+      - name: Run tests with coverage
+        run: |
+          if which dart >/dev/null 2>&1; then
+            echo "Using Dart at $(which dart)"
+            dart test --coverage
+          else
+            echo "::warning::dart CLI not found; using flutter" >&2
+            flutter test --coverage
+          fi
       - run: dart test integration_test/
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3
@@ -487,8 +523,15 @@ jobs:
       - run: flutter analyze
       - run: dart analyze
       - run: flutter pub downgrade || true
-      - run: flutter test --coverage
-      - run: dart test --coverage
+      - name: Run tests with coverage
+        run: |
+          if which dart >/dev/null 2>&1; then
+            echo "Using Dart at $(which dart)"
+            dart test --coverage
+          else
+            echo "::warning::dart CLI not found; using flutter" >&2
+            flutter test --coverage
+          fi
       - run: dart test integration_test/
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Run tests with coverage
         run: |
           if command -v dart >/dev/null 2>&1; then
+            echo "Using Dart at $(which dart)"
             dart test --coverage
           else
             echo "::warning::dart CLI not found; using flutter" >&2

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -59,7 +59,15 @@ jobs:
         run: flutter pub get --offline
       - run: flutter analyze
       - run: dart analyze
-      - run: flutter test --coverage test/
+      - name: Run tests with coverage
+        run: |
+          if which dart >/dev/null 2>&1; then
+            echo "Using Dart at $(which dart)"
+            dart test --coverage test/
+          else
+            echo "::warning::dart CLI not found; using flutter" >&2
+            flutter test --coverage test/
+          fi
       - run: dart test integration_test/
       - run: flutter build web
       - name: Upload coverage artifact


### PR DESCRIPTION
## Summary
- ensure dart CLI path is logged in workflows
- fallback to flutter test when dart is missing in CI

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fb92d87b88324ac62d13c495284bd