### PR TITLE
Fix emulator download firewall check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
           FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
     steps:
       - uses: actions/checkout@v4
+      - name: Check required network access
+        run: |
+          for host in storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
+            curl --head --fail https://$host || { echo "❌ Cannot reach $host" >&2; exit 1; }
+          done
       - name: Fetch tags
         run: git fetch --tags
       - name: Setup Flutter SDK
@@ -110,6 +115,11 @@ jobs:
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
       - uses: actions/checkout@v4
+      - name: Check required network access
+        run: |
+          for host in storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
+            curl --head --fail https://$host || { echo "❌ Cannot reach $host" >&2; exit 1; }
+          done
       - name: Fetch tags
         run: git fetch --tags
       - name: Setup Flutter SDK
@@ -174,6 +184,11 @@ jobs:
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
       - uses: actions/checkout@v4
+      - name: Check required network access
+        run: |
+          for host in storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
+            curl --head --fail https://$host || { echo "❌ Cannot reach $host" >&2; exit 1; }
+          done
       - name: Fetch tags
         run: git fetch --tags
       - name: Setup Flutter SDK
@@ -230,6 +245,11 @@ jobs:
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
       - uses: actions/checkout@v4
+      - name: Check required network access
+        run: |
+          for host in storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
+            curl --head --fail https://$host || { echo "❌ Cannot reach $host" >&2; exit 1; }
+          done
       - name: Fetch tags
         run: git fetch --tags
       - name: Setup Flutter SDK
@@ -302,6 +322,11 @@ jobs:
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
       - uses: actions/checkout@v4
+      - name: Check required network access
+        run: |
+          for host in storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
+            curl --head --fail https://$host || { echo "❌ Cannot reach $host" >&2; exit 1; }
+          done
       - name: Fetch tags
         run: git fetch --tags
       - name: Setup Flutter SDK
@@ -373,6 +398,11 @@ jobs:
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
       - uses: actions/checkout@v4
+      - name: Check required network access
+        run: |
+          for host in storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
+            curl --head --fail https://$host || { echo "❌ Cannot reach $host" >&2; exit 1; }
+          done
       - name: Fetch tags
         run: git fetch --tags
       - name: Setup Flutter SDK
@@ -444,6 +474,11 @@ jobs:
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
       - uses: actions/checkout@v4
+      - name: Check required network access
+        run: |
+          for host in storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
+            curl --head --fail https://$host || { echo "❌ Cannot reach $host" >&2; exit 1; }
+          done
       - name: Fetch tags
         run: git fetch --tags
       - name: Setup Flutter SDK

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -16,6 +16,11 @@ jobs:
       FLUTTER_CACHE_DIR: ~/.flutter
     steps:
       - uses: actions/checkout@v3
+      - name: Check required network access
+        run: |
+          for host in storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
+            curl --head --fail https://$host || { echo "❌ Cannot reach $host" >&2; exit 1; }
+          done
       - name: Setup Flutter SDK
         uses: flutter-actions/setup-flutter@v2
         with:

--- a/.github/workflows/flutter_web.yml
+++ b/.github/workflows/flutter_web.yml
@@ -16,6 +16,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Check required network access
+      run: |
+        for host in storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
+          curl --head --fail https://$host || { echo "❌ Cannot reach $host" >&2; exit 1; }
+        done
     - name: Setup Flutter SDK
       uses: flutter-actions/setup-flutter@v2
       with:

--- a/scripts/update_network_allowlist.sh
+++ b/scripts/update_network_allowlist.sh
@@ -12,7 +12,17 @@ if [[ -z "$ENTERPRISE" || -z "$TOKEN" ]]; then
   exit 1
 fi
 
-BODY='{"domains":["storage.googleapis.com","firebase-public.firebaseio.com","metadata.google.internal","169.254.169.254","raw.githubusercontent.com","pub.dev"]}'
+DOMAINS=(
+  storage.googleapis.com
+  firebase-public.firebaseio.com
+  metadata.google.internal
+  169.254.169.254
+  raw.githubusercontent.com
+  pub.dev
+)
+
+DOMAINS_JSON=$(printf '"%s",' "${DOMAINS[@]}" | sed 's/,$//')
+BODY="{\"domains\":[${DOMAINS_JSON}]}"
 
 curl -sSL -X PUT \
   -H "Authorization: Bearer ${TOKEN}" \


### PR DESCRIPTION
## Summary
- add connectivity probes to all workflows so Firebase emulators can download
- update `update_network_allowlist.sh` script to build JSON from a domain list

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fb91f420083249eb30d0b74ae4a50