### PR TITLE
Add bio length limit and counter

### DIFF
--- a/lib/features/profile/ui/edit_profile_screen.dart
+++ b/lib/features/profile/ui/edit_profile_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 class EditProfileScreen extends StatefulWidget {
   const EditProfileScreen({super.key});
@@ -35,9 +36,26 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
               decoration: const InputDecoration(labelText: 'Name'),
             ),
             const SizedBox(height: 8),
-            TextField(
-              controller: _bioController,
-              decoration: const InputDecoration(labelText: 'Bio'),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                TextFormField(
+                  controller: _bioController,
+                  inputFormatters: [
+                    LengthLimitingTextInputFormatter(150),
+                  ],
+                  onChanged: (_) => setState(() {}),
+                  decoration: const InputDecoration(labelText: 'Bio'),
+                ),
+                const SizedBox(height: 4),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: Text(
+                    '${_bioController.text.length}/150',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ),
+              ],
             ),
             const SizedBox(height: 8),
             TextField(

--- a/test/features/profile/edit_profile_screen_test.dart
+++ b/test/features/profile/edit_profile_screen_test.dart
@@ -11,7 +11,8 @@ Future<void> main() async {
       await tester.pumpWidget(const MaterialApp(home: EditProfileScreen()));
 
       expect(find.text('Edit Profile'), findsOneWidget);
-      expect(find.byType(TextField), findsNWidgets(3));
+      expect(find.byType(TextField), findsNWidgets(2));
+      expect(find.byType(TextFormField), findsOneWidget);
       expect(find.text('Name'), findsOneWidget);
       expect(find.text('Bio'), findsOneWidget);
       expect(find.text('Location'), findsOneWidget);

--- a/test/ui/edit_profile_screen_test.dart
+++ b/test/ui/edit_profile_screen_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:appoint/features/profile/ui/edit_profile_screen.dart';
+import '../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  group('EditProfileScreen bio field', () {
+    testWidgets('shows live character count and enforces max length',
+        (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: EditProfileScreen()));
+
+      final bioField = find.byType(TextFormField);
+      await tester.enterText(bioField, 'a' * 10);
+      await tester.pump();
+      expect(find.text('10/150'), findsOneWidget);
+
+      await tester.enterText(bioField, 'b' * 200);
+      await tester.pump();
+
+      final textField = tester.widget<TextFormField>(bioField);
+      expect(textField.controller!.text.length, lessThanOrEqualTo(150));
+      expect(find.text('150/150'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- enforce length limit and character counter in EditProfileScreen bio field
- update existing EditProfileScreen test
- add new widget test verifying bio character limit

## Testing
- `firebase emulators:start --only auth,firestore` *(fails: `firebase: command not found`)*
- `/workspace/flutter_sdk/bin/dart test --coverage` *(fails: Flutter SDK not available)*
- `/workspace/flutter_sdk/bin/flutter test --coverage` *(fails: some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_685fbbe39cf4832488f6f15becfa94a7