### PR TITLE
Add shared RetryButton widget

### DIFF
--- a/lib/common/ui/error_screen.dart
+++ b/lib/common/ui/error_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:appoint/components/common/retry_button.dart';
 
 /// Generic screen to display an error with a retry option.
 class ErrorScreen extends StatelessWidget {
@@ -21,10 +22,7 @@ class ErrorScreen extends StatelessWidget {
           const SizedBox(height: 16),
           Text(message, textAlign: TextAlign.center),
           const SizedBox(height: 24),
-          ElevatedButton(
-            onPressed: onRetry,
-            child: const Text('Retry'),
-          ),
+          RetryButton(onPressed: onRetry),
         ],
       ),
     );

--- a/lib/components/common/retry_button.dart
+++ b/lib/components/common/retry_button.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+/// Reusable icon button for retry actions.
+class RetryButton extends StatelessWidget {
+  /// Callback when the user taps the button.
+  final VoidCallback onPressed;
+
+  const RetryButton({super.key, required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        IconButton(
+          onPressed: onPressed,
+          icon: const Icon(Icons.refresh),
+        ),
+        const SizedBox(height: 4),
+        const Text('Try Again'),
+      ],
+    );
+  }
+}

--- a/lib/features/common/ui/error_screen.dart
+++ b/lib/features/common/ui/error_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:appoint/components/common/retry_button.dart';
 
 /// Simple error screen with retry action.
 class ErrorScreen extends StatelessWidget {
@@ -29,10 +30,7 @@ class ErrorScreen extends StatelessWidget {
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 24),
-            ElevatedButton(
-              onPressed: onTryAgain,
-              child: const Text('Try Again'),
-            ),
+            RetryButton(onPressed: onTryAgain),
           ],
         ),
       ),

--- a/test/common/ui/error_screen_test.dart
+++ b/test/common/ui/error_screen_test.dart
@@ -20,8 +20,8 @@ Future<void> main() async {
 
       expect(find.byIcon(Icons.error), findsOneWidget);
       expect(find.text('Failed'), findsOneWidget);
-      expect(find.text('Retry'), findsOneWidget);
-      expect(find.byType(ElevatedButton), findsOneWidget);
+      expect(find.text('Try Again'), findsOneWidget);
+      expect(find.byType(IconButton), findsOneWidget);
     });
   });
 }

--- a/test/components/common/retry_button_test.dart
+++ b/test/components/common/retry_button_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/components/common/retry_button.dart';
+import '../../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  group('RetryButton', () {
+    testWidgets('renders and triggers tap', (tester) async {
+      var tapped = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RetryButton(onPressed: () => tapped = true),
+        ),
+      );
+
+      expect(find.text('Try Again'), findsOneWidget);
+      expect(find.byIcon(Icons.refresh), findsOneWidget);
+
+      await tester.tap(find.byType(IconButton));
+      await tester.pumpAndSettle();
+      expect(tapped, isTrue);
+    });
+  });
+}

--- a/test/features/common/ui/error_screen_test.dart
+++ b/test/features/common/ui/error_screen_test.dart
@@ -21,7 +21,7 @@ Future<void> main() async {
       expect(find.byIcon(Icons.error_outline), findsOneWidget);
       expect(find.text('Oops'), findsOneWidget);
       expect(find.text('Try Again'), findsOneWidget);
-      expect(find.byType(ElevatedButton), findsOneWidget);
+      expect(find.byType(IconButton), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary
- add `RetryButton` widget for reusability
- update error screens to use the new widget
- add tests covering `RetryButton` and updated error screens

## Testing
- `dart test --coverage` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_685fbc07ba0c832499162fd24a30558a