### PR TITLE
🕒 Show comment timestamps as relative time with localization

### DIFF
--- a/lib/features/personal_app/ui/comment_item.dart
+++ b/lib/features/personal_app/ui/comment_item.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+import '../../../models/comment.dart';
+import '../../../utils/localized_date_formatter.dart';
+
+/// Displays a single comment with a relative timestamp.
+class CommentItem extends StatelessWidget {
+  final Comment comment;
+
+  const CommentItem({super.key, required this.comment});
+
+  @override
+  Widget build(BuildContext context) {
+    final timestamp =
+        LocalizedDateFormatter.relativeTimeFromNow(comment.createdAt);
+
+    return Card(
+      child: ListTile(
+        title: Text(comment.text),
+        subtitle: Text(timestamp),
+      ),
+    );
+  }
+}

--- a/lib/features/personal_app/ui/comments_screen.dart
+++ b/lib/features/personal_app/ui/comments_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../models/comment.dart';
 import '../../../services/comment_service.dart';
+import 'comment_item.dart';
 
 /// Simple comments UI showing a list of comments with an input box.
 class CommentsScreen extends StatefulWidget {
@@ -56,7 +57,7 @@ class _CommentsScreenState extends State<CommentsScreen> {
               itemCount: _comments.length,
               itemBuilder: (context, index) {
                 final comment = _comments[index];
-                return CommentCard(comment: comment);
+                return CommentItem(comment: comment);
               },
             ),
           ),
@@ -81,21 +82,6 @@ class _CommentsScreenState extends State<CommentsScreen> {
             ),
           ),
         ],
-      ),
-    );
-  }
-}
-
-class CommentCard extends StatelessWidget {
-  final Comment comment;
-
-  const CommentCard({super.key, required this.comment});
-
-  @override
-  Widget build(BuildContext context) {
-    return Card(
-      child: ListTile(
-        title: Text(comment.text),
       ),
     );
   }

--- a/lib/utils/localized_date_formatter.dart
+++ b/lib/utils/localized_date_formatter.dart
@@ -1,0 +1,49 @@
+import 'package:intl/intl.dart';
+
+/// Provides relative date formatting utilities.
+class LocalizedDateFormatter {
+  /// Returns a human friendly time string like "2 minutes ago" for the given
+  /// [timestamp].
+  static String relativeTimeFromNow(DateTime timestamp) {
+    final now = DateTime.now();
+    final diff = now.difference(timestamp);
+
+    if (diff.inMinutes < 1) {
+      return Intl.message('just now', name: 'justNow');
+    }
+
+    if (diff.inMinutes < 60) {
+      final minutes = diff.inMinutes;
+      return Intl.plural(
+        minutes,
+        one: '$minutes minute ago',
+        other: '$minutes minutes ago',
+        name: 'minutesAgo',
+        args: [minutes],
+        examples: const {'minutes': 2},
+      );
+    }
+
+    if (diff.inHours < 24) {
+      final hours = diff.inHours;
+      return Intl.plural(
+        hours,
+        one: '$hours hour ago',
+        other: '$hours hours ago',
+        name: 'hoursAgo',
+        args: [hours],
+        examples: const {'hours': 2},
+      );
+    }
+
+    final days = diff.inDays;
+    return Intl.plural(
+      days,
+      one: '$days day ago',
+      other: '$days days ago',
+      name: 'daysAgo',
+      args: [days],
+      examples: const {'days': 2},
+    );
+  }
+}

--- a/test/ui/comments/comment_item_test.dart
+++ b/test/ui/comments/comment_item_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/features/personal_app/ui/comment_item.dart';
+import 'package:appoint/models/comment.dart';
+import '../../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  group('CommentItem', () {
+    testWidgets('renders relative time', (tester) async {
+      final timestamp = DateTime.now().subtract(const Duration(minutes: 2));
+      await tester.pumpWidget(
+        MaterialApp(
+          home: CommentItem(
+            comment: Comment(id: '1', text: 'Hello', createdAt: timestamp),
+          ),
+        ),
+      );
+
+      expect(find.text('Hello'), findsOneWidget);
+      expect(find.textContaining('minute'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- refactor comments to use a new `CommentItem`
- add `LocalizedDateFormatter.relativeTimeFromNow`
- show comment times as relative values
- cover new behavior in widget tests

## Testing
- `../flutter_sdk/bin/flutter pub get`
- `../flutter_sdk/bin/flutter test --coverage` *(fails: Flutter tool couldn't run)*

------
https://chatgpt.com/codex/tasks/task_e_685fbc14b214832495da75c4d0b2820a