### PR TITLE
🌍 Add LocalizedDateFormatter utility

### DIFF
--- a/lib/features/personal_app/ui/comments_screen.dart
+++ b/lib/features/personal_app/ui/comments_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../models/comment.dart';
 import '../../../services/comment_service.dart';
+import '../../../utils/localized_date_formatter.dart';
 
 /// Simple comments UI showing a list of comments with an input box.
 class CommentsScreen extends StatefulWidget {
@@ -93,9 +94,16 @@ class CommentCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final locale = Localizations.localeOf(context).toLanguageTag();
     return Card(
       child: ListTile(
         title: Text(comment.text),
+        subtitle: Text(
+          LocalizedDateFormatter.formatRelativeTime(
+            comment.createdAt,
+            locale: locale,
+          ),
+        ),
       ),
     );
   }

--- a/lib/features/personal_app/ui/content_detail_screen.dart
+++ b/lib/features/personal_app/ui/content_detail_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../../../utils/localized_date_formatter.dart';
 
 /// TODO: Implement detailed content view
 class ContentDetailScreen extends StatelessWidget {
@@ -8,10 +9,23 @@ class ContentDetailScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final locale = Localizations.localeOf(context).toLanguageTag();
     return Scaffold(
       appBar: AppBar(title: const Text('Content Detail')),
       body: Center(
-        child: Text('Content ID: $contentId'),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('Content ID: $contentId'),
+            const SizedBox(height: 8),
+            Text(
+              LocalizedDateFormatter.formatFullDate(
+                DateTime.now(),
+                locale: locale,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/utils/localized_date_formatter.dart
+++ b/lib/utils/localized_date_formatter.dart
@@ -1,0 +1,31 @@
+import 'package:intl/intl.dart';
+
+/// Utility class for locale-aware date formatting.
+class LocalizedDateFormatter {
+  LocalizedDateFormatter._();
+
+  /// Formats [date] using the full year, month and day pattern for [locale].
+  static String formatFullDate(DateTime date, {String? locale}) {
+    final formatter = DateFormat.yMMMMd(locale);
+    return formatter.format(date);
+  }
+
+  /// Returns a human readable relative time string for [date].
+  /// For older dates (7+ days) falls back to [formatFullDate].
+  static String formatRelativeTime(DateTime date, {String? locale}) {
+    final now = DateTime.now();
+    final diff = now.difference(date);
+
+    if (diff.inSeconds < 60) {
+      return 'just now';
+    } else if (diff.inMinutes < 60) {
+      return '${diff.inMinutes} minutes ago';
+    } else if (diff.inHours < 24) {
+      return '${diff.inHours} hours ago';
+    } else if (diff.inDays < 7) {
+      return '${diff.inDays} days ago';
+    } else {
+      return formatFullDate(date, locale: locale);
+    }
+  }
+}

--- a/test/utils/localized_date_formatter_test.dart
+++ b/test/utils/localized_date_formatter_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+
+import 'package:appoint/utils/localized_date_formatter.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await initializeDateFormatting('en');
+    await initializeDateFormatting('fr');
+    await initializeDateFormatting('he');
+    await initializeDateFormatting('ja');
+  });
+
+  group('LocalizedDateFormatter', () {
+    test('formatFullDate returns localized strings', () {
+      final date = DateTime(2023, 9, 10);
+      expect(LocalizedDateFormatter.formatFullDate(date, locale: 'en'),
+          'September 10, 2023');
+      expect(LocalizedDateFormatter.formatFullDate(date, locale: 'fr'),
+          '10 septembre 2023');
+      expect(LocalizedDateFormatter.formatFullDate(date, locale: 'he'),
+          '10 \u05E1\u05E4\u05D8\u05DE\u05D1\u05E8 2023');
+      expect(LocalizedDateFormatter.formatFullDate(date, locale: 'ja'),
+          '2023\u5E749\u670810\u65E5');
+    });
+
+    test('formatRelativeTime returns human readable string', () {
+      final base = DateTime.now().subtract(const Duration(minutes: 5));
+      expect(
+        LocalizedDateFormatter.formatRelativeTime(base, locale: 'en'),
+        '5 minutes ago',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `LocalizedDateFormatter` utility class
- show formatted date on `ContentDetailScreen`
- show relative comment timestamps on `CommentsScreen`
- add unit tests for the formatter

## Testing
- `dart test --coverage=coverage` *(fails: Locale/Flutter compile errors)*
- `flutter test test/utils/localized_date_formatter_test.dart` *(fails: missing Flutter dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685fbbf9b8b4832493328bf5b7217385