### PR TITLE
Implement UI scaffold and helpers

### DIFF
--- a/lib/components/common/app_scaffold.dart
+++ b/lib/components/common/app_scaffold.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import '../../config/theme.dart';
+
+class AppScaffold extends StatelessWidget {
+  final Widget child;
+  final String? title;
+
+  const AppScaffold({Key? key, required this.child, this.title}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppTheme.backgroundColor,
+      appBar: title != null ? AppBar(title: Text(title!)) : null,
+      body: SafeArea(child: child),
+    );
+  }
+}

--- a/lib/components/common/empty_state.dart
+++ b/lib/components/common/empty_state.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import '../../config/theme.dart';
+
+class EmptyState extends StatelessWidget {
+  final String title;
+  final IconData icon;
+  final String? description;
+
+  const EmptyState({
+    Key? key,
+    required this.title,
+    this.icon = Icons.inbox,
+    this.description,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 48, color: AppTheme.secondaryColor),
+          const SizedBox(height: 8),
+          Text(title, style: Theme.of(context).textTheme.headlineSmall),
+          if (description != null) ...[
+            const SizedBox(height: 4),
+            Text(
+              description!,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/components/common/section_divider.dart
+++ b/lib/components/common/section_divider.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import '../../config/theme.dart';
+
+class SectionDivider extends StatelessWidget {
+  final String? label;
+  const SectionDivider({Key? key, this.label}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (label != null) ...[
+          Text(
+            label!,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          const SizedBox(height: 4),
+        ],
+        Divider(color: AppTheme.secondaryColor),
+      ],
+    );
+  }
+}

--- a/lib/config/theme.dart
+++ b/lib/config/theme.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../theme/app_colors.dart';
+import '../theme/typography.dart';
 
 class AppTheme {
   // Color constants centralized in [AppColors]
@@ -18,6 +19,7 @@ class AppTheme {
       background: AppColors.background,
       error: AppColors.error,
     ),
+    textTheme: AppTypography.textTheme,
   );
 
   static final ThemeData darkTheme = ThemeData(
@@ -28,5 +30,6 @@ class AppTheme {
       background: AppColors.background,
       error: AppColors.error,
     ),
+    textTheme: AppTypography.textTheme,
   );
 }

--- a/lib/constants/countries.dart
+++ b/lib/constants/countries.dart
@@ -1,0 +1,11 @@
+const Map<String, String> countries = {
+  'US': 'United States',
+  'IL': 'Israel',
+  'GB': 'United Kingdom',
+  'DE': 'Germany',
+  'FR': 'France',
+};
+
+String getCountryName(String code) {
+  return countries[code.toUpperCase()] ?? 'Unknown';
+}

--- a/lib/constants/languages.dart
+++ b/lib/constants/languages.dart
@@ -1,0 +1,11 @@
+const List<String> supportedLanguages = [
+  'en', 'es', 'fr', 'de', 'it', 'pt', 'ru', 'ja', 'ko', 'zh',
+  'ar', 'hi', 'bn', 'ur', 'fa', 'tr', 'nl', 'pl', 'sv', 'da',
+  'no', 'fi', 'cs', 'sk', 'hu', 'ro', 'bg', 'hr', 'sl', 'et',
+  'lv', 'lt', 'mt', 'ga', 'cy', 'eu', 'ca', 'gl', 'is', 'fo',
+  'sq', 'mk', 'sr', 'bs'
+];
+
+bool isSupportedLanguage(String code) {
+  return supportedLanguages.contains(code.toLowerCase());
+}

--- a/lib/theme/typography.dart
+++ b/lib/theme/typography.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class AppTypography {
+  static const TextStyle headline1 = TextStyle(
+    fontSize: 32,
+    fontWeight: FontWeight.bold,
+  );
+
+  static const TextStyle headline2 = TextStyle(
+    fontSize: 24,
+    fontWeight: FontWeight.w600,
+  );
+
+  static const TextStyle bodyText = TextStyle(
+    fontSize: 16,
+  );
+
+  static const TextStyle caption = TextStyle(
+    fontSize: 12,
+    color: Colors.grey,
+  );
+
+  static const TextTheme textTheme = TextTheme(
+    headlineLarge: headline1,
+    headlineMedium: headline2,
+    bodyMedium: bodyText,
+    bodySmall: caption,
+  );
+}

--- a/test/components/common/app_scaffold_test.dart
+++ b/test/components/common/app_scaffold_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/components/common/app_scaffold.dart';
+import '../../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  group('AppScaffold', () {
+    testWidgets('renders with title', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: AppScaffold(
+            title: 'Home',
+            child: Text('content'),
+          ),
+        ),
+      );
+
+      expect(find.text('Home'), findsOneWidget);
+      expect(find.byType(AppBar), findsOneWidget);
+      expect(find.byType(SafeArea), findsOneWidget);
+    });
+
+    testWidgets('renders without title', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: AppScaffold(child: Text('content')),
+        ),
+      );
+
+      expect(find.byType(AppBar), findsNothing);
+      expect(find.byType(SafeArea), findsOneWidget);
+    });
+  });
+}

--- a/test/components/common/empty_state_test.dart
+++ b/test/components/common/empty_state_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/components/common/empty_state.dart';
+import '../../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  group('EmptyState', () {
+    testWidgets('renders with default icon', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: EmptyState(title: 'No items'),
+        ),
+      );
+
+      expect(find.text('No items'), findsOneWidget);
+      expect(find.byIcon(Icons.inbox), findsOneWidget);
+    });
+
+    testWidgets('renders with custom icon', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: EmptyState(title: 'Empty', icon: Icons.error),
+        ),
+      );
+
+      expect(find.byIcon(Icons.error), findsOneWidget);
+    });
+  });
+}

--- a/test/components/common/section_divider_test.dart
+++ b/test/components/common/section_divider_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/components/common/section_divider.dart';
+import '../../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  group('SectionDivider', () {
+    testWidgets('renders without label', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SectionDivider(),
+        ),
+      );
+
+      expect(find.byType(Divider), findsOneWidget);
+      expect(find.byType(Text), findsNothing);
+    });
+
+    testWidgets('renders with label', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SectionDivider(label: 'Section'),
+        ),
+      );
+
+      expect(find.text('Section'), findsOneWidget);
+      expect(find.byType(Divider), findsOneWidget);
+    });
+  });
+}

--- a/test/constants/countries_test.dart
+++ b/test/constants/countries_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/constants/countries.dart';
+import '../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  group('Countries', () {
+    test('valid code returns name', () {
+      expect(getCountryName('IL'), 'Israel');
+    });
+
+    test('invalid code returns Unknown', () {
+      expect(getCountryName('XX'), 'Unknown');
+    });
+  });
+}

--- a/test/constants/languages_test.dart
+++ b/test/constants/languages_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/constants/languages.dart';
+import '../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  group('Languages', () {
+    test('recognizes supported language', () {
+      expect(isSupportedLanguage('en'), isTrue);
+    });
+
+    test('rejects unsupported language', () {
+      expect(isSupportedLanguage('xx'), isFalse);
+    });
+  });
+}

--- a/test/theme/typography_test.dart
+++ b/test/theme/typography_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/config/theme.dart';
+import 'package:appoint/theme/typography.dart';
+import '../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  test('AppTheme includes typography', () {
+    expect(AppTheme.lightTheme.textTheme, AppTypography.textTheme);
+  });
+}


### PR DESCRIPTION
## Summary
- add reusable `AppScaffold` widget
- add `EmptyState` and `SectionDivider` widgets
- add typography configuration
- provide country and language helpers
- wire typography into `AppTheme`
- test new widgets and helpers

## Testing
- `dart test --coverage` *(fails: Dart SDK version 3.3.0 < 3.4.0)*

------
https://chatgpt.com/codex/tasks/task_e_685fdec1e81c832488e2f9c03163b3b8