### PR TITLE
Update Dart toolchain and CI setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,4 +11,7 @@
     }
   },
   "features": {}
+  ,"mounts": [
+    "source=${localEnv:HOME}/.pub-cache,target=/root/.pub-cache,type=bind"
+  ]
 }

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -27,6 +27,10 @@ jobs:
         uses: flutter-actions/setup-flutter@v2
         with:
           flutter-version: '3.20.0'
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: '3.4.0'
       - name: Ensure Flutter & Dart in PATH
         run: |
           echo "$HOME/.flutter/bin" >> $GITHUB_PATH

--- a/packages/fl_chart_stub/pubspec.yaml
+++ b/packages/fl_chart_stub/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fl_chart
 version: 0.0.1
 environment:
-  sdk: '>=3.0.0'
+  sdk: '>=3.4.0 <4.0.0'
 dependencies:
   flutter:
     sdk: flutter

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bootstrap Flutter and Dart environment
+# Installs Flutter 3.32.0 and Dart 3.4.0, then runs checks.
+
+FLUTTER_VERSION="3.32.0"
+DART_VERSION="3.4.0"
+
+# Install Flutter if missing
+if ! command -v flutter >/dev/null 2>&1; then
+  echo "Downloading Flutter $FLUTTER_VERSION..."
+  curl -L "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz" -o flutter.tar.xz
+  mkdir -p "$HOME"
+  tar xf flutter.tar.xz -C "$HOME"
+  rm flutter.tar.xz
+  export PATH="$HOME/flutter/bin:$PATH"
+fi
+
+# Install Dart SDK
+if ! command -v dart >/dev/null 2>&1 || ! dart --version 2>&1 | grep -q "$DART_VERSION"; then
+  echo "Installing Dart $DART_VERSION..."
+  curl -L "https://storage.googleapis.com/dart-archive/channels/stable/release/${DART_VERSION}/sdk/dartsdk-linux-x64-release.zip" -o dartsdk.zip
+  unzip -q dartsdk.zip -d "$HOME/dart-sdk"
+  rm dartsdk.zip
+  export PATH="$HOME/dart-sdk/dart-sdk/bin:$PATH"
+fi
+
+# Accept Android licenses if needed
+if command -v flutter >/dev/null 2>&1; then
+  yes | flutter doctor --android-licenses
+fi
+
+# Fetch dependencies and run checks
+flutter pub get
+
+dart pub get
+
+flutter analyze
+dart test


### PR DESCRIPTION
## Summary
- allow Dart 3.4 in `fl_chart_stub`
- mount pub-cache in devcontainer
- install Dart 3.4.0 in Flutter workflow
- add environment bootstrap script `setup.sh`

## Testing
- `npm install -g firebase-tools`
- `dart pub get` *(failed: requires Dart 3.4)*
- `dart test --coverage` *(failed: requires Dart 3.4)*


------
https://chatgpt.com/codex/tasks/task_e_685fe16e13b4832498cac1af2b7066ab