### PR TITLE
Integrate Firebase Crashlytics

### DIFF
--- a/lib/infra/crashlytics_service.dart
+++ b/lib/infra/crashlytics_service.dart
@@ -1,9 +1,11 @@
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+
 class CrashlyticsService {
   Future<void> log(String message) async {
-    // Replace with FirebaseCrashlytics.instance.log(message);
+    await FirebaseCrashlytics.instance.log(message);
   }
 
   Future<void> recordError(dynamic error, StackTrace? stack) async {
-    // Replace with FirebaseCrashlytics.instance.recordError(...);
+    await FirebaseCrashlytics.instance.recordError(error, stack, fatal: false);
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'dart:async';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'l10n/app_localizations.dart';
 import 'config/routes.dart';
@@ -20,6 +22,18 @@ Future<void> appMain() async {
     options: DefaultFirebaseOptions.currentPlatform,
   );
 
+  // Enable Crashlytics collection
+  await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(true);
+
+  // Forward Flutter errors to Crashlytics
+  FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterError;
+
+  // Forward Dart errors to Crashlytics
+  PlatformDispatcher.instance.onError = (error, stack) {
+    FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
+    return true;
+  };
+
   // Initialize Firebase Analytics
   await FirebaseAnalytics.instance.setAnalyticsCollectionEnabled(true);
 
@@ -33,10 +47,16 @@ Future<void> appMain() async {
   final notificationService = NotificationService();
   await notificationService.initialize();
 
-  runApp(
-    ProviderScope(
-      child: MyApp(deepLinkService: deepLinkService),
-    ),
+  runZonedGuarded(
+    () {
+      runApp(
+        ProviderScope(
+          child: MyApp(deepLinkService: deepLinkService),
+        ),
+      );
+    },
+    (error, stack) =>
+        FirebaseCrashlytics.instance.recordError(error, stack, fatal: true),
   );
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   cloud_functions: ^4.7.5
   firebase_analytics: ^10.4.0
   firebase_storage: ^11.5.1
-  firebase_crashlytics: 3.5.7
+  firebase_crashlytics: ^3.5.7
   firebase_app_check: ^0.2.1+8
   flutter_stripe: ^11.5.0
   flutter_riverpod: 2.6.1


### PR DESCRIPTION
## Summary
- add firebase_crashlytics dependency
- wire up Firebase Crashlytics service
- initialize Crashlytics in `main.dart` and capture uncaught errors

## Testing
- `flutter pub get` *(fails: The current Dart SDK version is 3.3.0)*
- `dart pub get` *(fails: The current Dart SDK version is 3.3.0)*
- `dart test --coverage` *(fails: The current Dart SDK version is 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_685fe23eae988324a0f4519b6a910f73