### PR TITLE
Fix Dart SDK constraint

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Flutter App",
-  "image": "ghcr.io/cirruslabs/flutter:stable",
-  "postCreateCommand": "flutter pub get",
+  "image": "dart:3.4",
+  "postCreateCommand": "dart pub get",
   "customizations": {
     "vscode": {
       "extensions": [
@@ -10,5 +10,8 @@
       ]
     }
   },
-  "features": {}
+  "features": {},
+  "mounts": [
+    "source=${localEnv:HOME}/.pub-cache,target=/root/.pub-cache,type=bind"
+  ]
 }

--- a/packages/fl_chart_stub/pubspec.yaml
+++ b/packages/fl_chart_stub/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fl_chart
 version: 0.0.1
 environment:
-  sdk: '>=3.0.0'
+  sdk: '>=3.4.0'
 dependencies:
   flutter:
     sdk: flutter


### PR DESCRIPTION
## Summary
- update stub package SDK to `>=3.4.0`
- install Dart 3.4.0 in the devcontainer and mount host pub cache

## Testing
- `dart pub get` *(fails: domain not in allowlist)*
- `dart test --coverage` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_685fe90f105c8324b526cec426ff41f8