### PR TITLE
Allow dart.dev in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check required network access
         run: |
-          for host in storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
+          for host in storage.googleapis.com pub.dev raw.githubusercontent.com dart.dev firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
             curl --head --fail https://$host || { echo "❌ Cannot reach $host" >&2; exit 1; }
           done
       - name: Fetch tags
@@ -56,7 +56,7 @@ jobs:
         run: |
     which dart
           dart --version
-          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com; do
+          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com dart.dev; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
       - name: Set up Node.js
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check required network access
         run: |
-          for host in storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
+          for host in storage.googleapis.com pub.dev raw.githubusercontent.com dart.dev firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
             curl --head --fail https://$host || { echo "❌ Cannot reach $host" >&2; exit 1; }
           done
       - name: Fetch tags
@@ -153,7 +153,7 @@ jobs:
         run: |
     which dart
           dart --version
-          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com; do
+          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com dart.dev; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
       - name: Set up Node.js
@@ -201,7 +201,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check required network access
         run: |
-          for host in storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
+          for host in storage.googleapis.com pub.dev raw.githubusercontent.com dart.dev firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
             curl --head --fail https://$host || { echo "❌ Cannot reach $host" >&2; exit 1; }
           done
       - name: Fetch tags
@@ -230,7 +230,7 @@ jobs:
         run: |
     which dart
           dart --version
-          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com; do
+          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com dart.dev; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
       - name: Set up Node.js
@@ -262,7 +262,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check required network access
         run: |
-          for host in storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
+          for host in storage.googleapis.com pub.dev raw.githubusercontent.com dart.dev firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
             curl --head --fail https://$host || { echo "❌ Cannot reach $host" >&2; exit 1; }
           done
       - name: Fetch tags
@@ -291,7 +291,7 @@ jobs:
         run: |
     which dart
           dart --version
-          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com; do
+          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com dart.dev; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
       - name: Set up Node.js
@@ -346,7 +346,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check required network access
         run: |
-          for host in storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
+          for host in storage.googleapis.com pub.dev raw.githubusercontent.com dart.dev firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
             curl --head --fail https://$host || { echo "❌ Cannot reach $host" >&2; exit 1; }
           done
       - name: Fetch tags
@@ -375,7 +375,7 @@ jobs:
         run: |
     which dart
           dart --version
-          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com; do
+          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com dart.dev; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
       - name: Set up Node.js
@@ -429,7 +429,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check required network access
         run: |
-          for host in storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
+          for host in storage.googleapis.com pub.dev raw.githubusercontent.com dart.dev firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
             curl --head --fail https://$host || { echo "❌ Cannot reach $host" >&2; exit 1; }
           done
       - name: Fetch tags
@@ -458,7 +458,7 @@ jobs:
         run: |
     which dart
           dart --version
-          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com; do
+          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com dart.dev; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
       - name: Set up Node.js
@@ -512,7 +512,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check required network access
         run: |
-          for host in storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
+          for host in storage.googleapis.com pub.dev raw.githubusercontent.com dart.dev firebase-public.firebaseio.com metadata.google.internal 169.254.169.254; do
             curl --head --fail https://$host || { echo "❌ Cannot reach $host" >&2; exit 1; }
           done
       - name: Fetch tags
@@ -541,7 +541,7 @@ jobs:
         run: |
     which dart
           dart --version
-          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com; do
+          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com dart.dev; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
       - name: Install Verdaccio

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Check required network access
         run: |
-          for host in storage.googleapis.com pub.dev raw.githubusercontent.com firebase.google.com; do
+          for host in storage.googleapis.com pub.dev raw.githubusercontent.com dart.dev firebase.google.com; do
             for i in 1 2 3; do
               curl --head --fail https://$host && break || sleep 5
             done
@@ -50,7 +50,7 @@ jobs:
         run: |
     which dart
           dart --version
-          for host in storage.googleapis.com pub.dev raw.githubusercontent.com firebase.google.com; do
+          for host in storage.googleapis.com pub.dev raw.githubusercontent.com dart.dev firebase.google.com; do
             curl --head --fail https://$host || { echo "❌ Cannot reach $host"; exit 1; }
           done
       - name: Get dependencies with retry

--- a/.github/workflows/flutter_web.yml
+++ b/.github/workflows/flutter_web.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Check required network access
       run: |
-        for host in storage.googleapis.com pub.dev raw.githubusercontent.com firebase.google.com; do
+        for host in storage.googleapis.com pub.dev raw.githubusercontent.com dart.dev firebase.google.com; do
           curl --head --fail https://$host || { echo "❌ Cannot reach $host" >&2; exit 1; }
         done
     - name: Setup Flutter SDK
@@ -46,7 +46,7 @@ jobs:
       run: |
     which dart
         dart --version
-        for host in storage.googleapis.com pub.dev raw.githubusercontent.com firebase.google.com; do
+        for host in storage.googleapis.com pub.dev raw.githubusercontent.com dart.dev firebase.google.com; do
           curl --head --fail https://$host || { echo "❌ Cannot reach $host"; exit 1; }
         done
     - run: flutter pub get

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
     which dart
           dart --version
-          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com; do
+          for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com dart.dev; do
             curl --head --fail https://$host || { echo "❌ Cannot reach $host"; exit 1; }
           done
       - name: Set up Node.js

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           flutter-version: '3.20.0'
       - run: echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+      - name: Configure Network Allowlist
+        run: |
+          scripts/update_network_allowlist.sh ${{ secrets.GHE_ENTERPRISE }} ${{ secrets.GHE_TOKEN }}
       - run: flutter pub get
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs

--- a/scripts/update_network_allowlist.sh
+++ b/scripts/update_network_allowlist.sh
@@ -19,6 +19,7 @@ DOMAINS=(
   169.254.169.254
   raw.githubusercontent.com
   pub.dev
+  dart.dev
 )
 
 DOMAINS_JSON=$(printf '"%s",' "${DOMAINS[@]}" | sed 's/,$//')


### PR DESCRIPTION
## Summary
- permit `dart.dev` in network allow list script
- ensure every workflow checks for the new domain
- update PR checks workflow to configure the network allow list

## Testing
- `dart test --coverage` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_685ff52067b08324bc66fe0cb75d52b2