### PR TITLE
Add test config

### DIFF
--- a/test/fake_firebase_setup.dart
+++ b/test/fake_firebase_setup.dart
@@ -1,10 +1,11 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'test_config.dart';
 import 'test_setup.dart';
 
 /// Initializes Firebase mocks for widget tests.
 Future<FirebaseApp> initializeTestFirebase() async {
-  TestWidgetsFlutterBinding.ensureInitialized();
+  setupTestConfig();
   setupFirebaseMocks();
   if (Firebase.apps.isEmpty) {
     await Firebase.initializeApp();

--- a/test/run_all_tests.dart
+++ b/test/run_all_tests.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'test_config.dart';
 import 'fake_firebase_setup.dart';
 
 // Import all test files
@@ -13,7 +14,7 @@ import 'features/admin/admin_broadcast_screen_test.dart'
 import 'features/auth/login_screen_test.dart' as login_screen_test;
 
 Future<void> main() async {
-  TestWidgetsFlutterBinding.ensureInitialized();
+  setupTestConfig();
   await initializeTestFirebase();
   group('All Tests', () {
     group('Model Tests', () {

--- a/test/test_config.dart
+++ b/test/test_config.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:firebase_core_platform_interface/test.dart';
+
+/// Ensures the widget binding is initialized and Firebase core mocks are set up
+/// before running tests.
+void setupTestConfig() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setupFirebaseCoreMocks();
+}
+
+void main() {
+  setupTestConfig();
+}

--- a/test/test_setup.dart
+++ b/test/test_setup.dart
@@ -6,6 +6,7 @@ import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_inte
 import 'package:firebase_crashlytics_platform_interface/firebase_crashlytics_platform_interface.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:firebase_core_platform_interface/test.dart';
+import 'test_config.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'mocks/service_mocks.mocks.dart';
 import '../lib/infra/firestore_service.dart';
@@ -19,16 +20,21 @@ import '../lib/generated/pigeon_firestore_api.dart';
 class MockFirebaseAuthPlatform extends Mock
     with MockPlatformInterfaceMixin
     implements FirebaseAuthPlatform {}
+
 class MockFirebaseFirestorePlatform extends Mock
     with MockPlatformInterfaceMixin
     implements FirebaseFirestorePlatform {}
+
 class MockFirebaseCrashlyticsPlatform extends Mock
     with MockPlatformInterfaceMixin
     implements FirebaseCrashlyticsPlatform {}
+
 class MockFilePicker extends Mock
     with MockPlatformInterfaceMixin
     implements FilePicker {}
+
 class MockAuthHostApi extends Mock implements AuthHostApi {}
+
 class MockFirestoreHostApi extends Mock implements FirestoreHostApi {}
 
 late MockFirestoreService mockFirestoreService;
@@ -36,9 +42,7 @@ late MockAuthService mockAuthService;
 late MockFirebaseStorageService mockStorageService;
 
 void setupFirebaseMocks() {
-  TestWidgetsFlutterBinding.ensureInitialized();
-
-  setupFirebaseCoreMocks();
+  setupTestConfig();
 
   setUpAll(() async {
     await Firebase.initializeApp();

--- a/test/test_setup_test.dart
+++ b/test/test_setup_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_auth_platform_interface/firebase_auth_platform_interface.dart';
+import 'test_config.dart';
 import 'test_setup.dart';
 
 void main() {
+  setupTestConfig();
   setupFirebaseMocks();
 
   test('setup loads without error', () {


### PR DESCRIPTION
## Summary
- stub `test/test_config.dart` for Dart test pre-setup
- use `setupTestConfig` in firebase test helpers and harnesses
- update existing tests to import new config

## Testing
- `dart format` on updated files
- `dart test --coverage` *(fails: storage.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685ff52b003c8324831ec7ec2c624b1f