### PR TITLE
Generate simple mocks for services

### DIFF
--- a/test/mocks/service_mocks.mocks.dart
+++ b/test/mocks/service_mocks.mocks.dart
@@ -1,0 +1,12 @@
+import 'package:mockito/mockito.dart';
+
+import '../../lib/core/auth_service.dart';
+import '../../lib/infra/firestore_service.dart';
+import '../../lib/infra/firebase_storage_service.dart';
+
+class MockFirestoreService extends Mock implements FirestoreService {}
+
+class MockAuthService extends Mock implements AuthService {}
+
+class MockFirebaseStorageService extends Mock
+    implements FirebaseStorageService {}

--- a/test/test_setup.dart
+++ b/test/test_setup.dart
@@ -19,21 +19,32 @@ import '../lib/generated/pigeon_firestore_api.dart';
 class MockFirebaseAuthPlatform extends Mock
     with MockPlatformInterfaceMixin
     implements FirebaseAuthPlatform {}
+
 class MockFirebaseFirestorePlatform extends Mock
     with MockPlatformInterfaceMixin
     implements FirebaseFirestorePlatform {}
+
 class MockFirebaseCrashlyticsPlatform extends Mock
     with MockPlatformInterfaceMixin
     implements FirebaseCrashlyticsPlatform {}
+
 class MockFilePicker extends Mock
     with MockPlatformInterfaceMixin
     implements FilePicker {}
+
 class MockAuthHostApi extends Mock implements AuthHostApi {}
+
 class MockFirestoreHostApi extends Mock implements FirestoreHostApi {}
 
 late MockFirestoreService mockFirestoreService;
 late MockAuthService mockAuthService;
 late MockFirebaseStorageService mockStorageService;
+
+void registerServiceMocks() {
+  mockFirestoreService = MockFirestoreService();
+  mockAuthService = MockAuthService();
+  mockStorageService = MockFirebaseStorageService();
+}
 
 void setupFirebaseMocks() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -51,8 +62,6 @@ void setupFirebaseMocks() {
     AuthHostApi.setup(MockAuthHostApi());
     FirestoreHostApi.setup(MockFirestoreHostApi());
 
-    mockFirestoreService = MockFirestoreService();
-    mockAuthService = MockAuthService();
-    mockStorageService = MockFirebaseStorageService();
+    registerServiceMocks();
   });
 }


### PR DESCRIPTION
## Summary
- add minimal Mockito mock classes for core services
- register these service mocks in `test_setup.dart`

## Testing
- `flutter pub run build_runner build` *(fails: Dart SDK version 3.3.0 < 3.4.0)*
- `dart run test --coverage` *(fails: Dart SDK version 3.3.0 < 3.4.0)*

------
https://chatgpt.com/codex/tasks/task_e_685ff53e7cac832492e670ffb54fbd78