### PR TITLE
Add referral code feature

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -35,6 +35,7 @@ import '../features/personal_app/ui/search_screen.dart';
 import '../features/personal_app/ui/content_detail_screen.dart';
 import '../features/personal_app/ui/notifications_screen.dart';
 import '../features/common/ui/error_screen.dart';
+import '../features/referral/referral_screen.dart';
 
 class AppRouter {
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
@@ -196,6 +197,11 @@ class AppRouter {
       case '/invite/list':
         return MaterialPageRoute(
           builder: (_) => const InviteListScreen(),
+          settings: settings,
+        );
+      case '/referral':
+        return MaterialPageRoute(
+          builder: (_) => const ReferralScreen(),
           settings: settings,
         );
       case '/content/:id':

--- a/lib/features/referral/referral_screen.dart
+++ b/lib/features/referral/referral_screen.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/referral_provider.dart';
+
+class ReferralScreen extends ConsumerWidget {
+  const ReferralScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final codeAsync = ref.watch(referralCodeProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Referral Code')),
+      body: Center(
+        child: codeAsync.when(
+          data: (code) => Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Text('Your referral code:'),
+              const SizedBox(height: 12),
+              SelectableText(
+                code,
+                style: Theme.of(context).textTheme.headlineMedium,
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton.icon(
+                icon: const Icon(Icons.copy),
+                label: const Text('Copy'),
+                onPressed: () {
+                  Clipboard.setData(ClipboardData(text: code));
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Copied to clipboard')),
+                  );
+                },
+              ),
+            ],
+          ),
+          loading: () => const CircularProgressIndicator(),
+          error: (e, _) => const Text('Error loading referral code'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/providers/referral_provider.dart
+++ b/lib/providers/referral_provider.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/referral_service.dart';
+
+final referralServiceProvider =
+    Provider<ReferralService>((ref) => ReferralService());
+
+final referralCodeProvider = FutureProvider<String>((ref) {
+  return ref.read(referralServiceProvider).generateReferralCode();
+});

--- a/lib/services/referral_service.dart
+++ b/lib/services/referral_service.dart
@@ -1,0 +1,53 @@
+import 'dart:math';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class ReferralService {
+  final FirebaseFirestore _firestore;
+  final FirebaseAuth _auth;
+
+  ReferralService({FirebaseFirestore? firestore, FirebaseAuth? auth})
+      : _firestore = firestore ?? FirebaseFirestore.instance,
+        _auth = auth ?? FirebaseAuth.instance;
+
+  Future<String> generateReferralCode() async {
+    final user = _auth.currentUser;
+    if (user == null) {
+      throw Exception('User not logged in');
+    }
+
+    // Return existing code if already generated
+    final existing = await _firestore
+        .collection('referral_codes')
+        .where('userId', isEqualTo: user.uid)
+        .limit(1)
+        .get();
+    if (existing.docs.isNotEmpty) {
+      return existing.docs.first.data()['code'] as String;
+    }
+
+    String code;
+    bool exists = true;
+    final random = Random();
+    const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+    do {
+      code =
+          List.generate(6, (_) => chars[random.nextInt(chars.length)]).join();
+      final query = await _firestore
+          .collection('referral_codes')
+          .where('code', isEqualTo: code)
+          .limit(1)
+          .get();
+      exists = query.docs.isNotEmpty;
+    } while (exists);
+
+    await _firestore.collection('referral_codes').add({
+      'userId': user.uid,
+      'code': code,
+      'createdAt': FieldValue.serverTimestamp(),
+    });
+
+    return code;
+  }
+}


### PR DESCRIPTION
## Summary
- add ReferralService to generate unique codes per user
- provide referralServiceProvider and referralCodeProvider
- show referral code and copy UI in new ReferralScreen
- route `/referral` to the new screen

## Testing
- `dart analyze` *(fails: Target of URI doesn't exist)*
- `dart test --coverage` *(fails: SDK version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_685ff548060083249fbe5b89d20f0da4