### PR TITLE
Add Rewards tracking screen and service

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -35,6 +35,7 @@ import '../features/personal_app/ui/search_screen.dart';
 import '../features/personal_app/ui/content_detail_screen.dart';
 import '../features/personal_app/ui/notifications_screen.dart';
 import '../features/common/ui/error_screen.dart';
+import '../features/rewards/rewards_screen.dart';
 
 class AppRouter {
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
@@ -207,6 +208,11 @@ class AppRouter {
       case '/notifications':
         return MaterialPageRoute(
           builder: (_) => const NotificationsScreen(),
+          settings: settings,
+        );
+      case '/rewards':
+        return MaterialPageRoute(
+          builder: (_) => const RewardsScreen(),
           settings: settings,
         );
       case '/search':

--- a/lib/features/rewards/rewards_screen.dart
+++ b/lib/features/rewards/rewards_screen.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/rewards_provider.dart';
+
+class RewardsScreen extends ConsumerWidget {
+  const RewardsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final pointsAsync = ref.watch(userPointsProvider);
+    final tiers = ref.watch(rewardTiersProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Rewards')),
+      body: pointsAsync.when(
+        data: (points) {
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              Card(
+                child: ListTile(
+                  title: const Text('Points Earned'),
+                  trailing: Text('$points'),
+                ),
+              ),
+              const SizedBox(height: 24),
+              Text('Reward Tiers',
+                  style: Theme.of(context).textTheme.titleLarge),
+              const SizedBox(height: 8),
+              ...tiers.map(
+                (tier) => ListTile(
+                  title: Text(tier.name),
+                  trailing: Text('${tier.pointsRequired} pts'),
+                ),
+              ),
+            ],
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, __) => const Center(child: Text('Error loading points')),
+      ),
+    );
+  }
+}

--- a/lib/models/reward_tier.dart
+++ b/lib/models/reward_tier.dart
@@ -1,0 +1,18 @@
+class RewardTier {
+  final String name;
+  final int pointsRequired;
+
+  const RewardTier({required this.name, required this.pointsRequired});
+
+  factory RewardTier.fromJson(Map<String, dynamic> json) {
+    return RewardTier(
+      name: json['name'] as String? ?? '',
+      pointsRequired: json['pointsRequired'] as int? ?? 0,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'pointsRequired': pointsRequired,
+      };
+}

--- a/lib/models/user_rewards.dart
+++ b/lib/models/user_rewards.dart
@@ -1,0 +1,18 @@
+class UserRewards {
+  final String id;
+  final int points;
+
+  UserRewards({required this.id, required this.points});
+
+  factory UserRewards.fromJson(Map<String, dynamic> json) {
+    return UserRewards(
+      id: json['id'] as String? ?? '',
+      points: json['points'] as int? ?? 0,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'points': points,
+      };
+}

--- a/lib/providers/rewards_provider.dart
+++ b/lib/providers/rewards_provider.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../models/reward_tier.dart';
+import '../services/rewards_service.dart';
+
+final rewardsServiceProvider =
+    Provider<RewardsService>((ref) => RewardsService());
+
+final rewardTiersProvider = Provider<List<RewardTier>>((ref) {
+  return ref.read(rewardsServiceProvider).rewardTiers;
+});
+
+final userPointsProvider = StreamProvider<int>((ref) {
+  final uid = FirebaseAuth.instance.currentUser?.uid;
+  if (uid == null) {
+    return const Stream<int>.value(0);
+  }
+  return ref.read(rewardsServiceProvider).watchPoints(uid);
+});

--- a/lib/services/rewards_service.dart
+++ b/lib/services/rewards_service.dart
@@ -1,0 +1,47 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../models/reward_tier.dart';
+
+class RewardsService {
+  final FirebaseFirestore _firestore;
+  final FirebaseAuth _auth;
+
+  RewardsService({FirebaseFirestore? firestore, FirebaseAuth? auth})
+      : _firestore = firestore ?? FirebaseFirestore.instance,
+        _auth = auth ?? FirebaseAuth.instance;
+
+  /// Adds [points] to the currently authenticated user.
+  Future<void> addPoints(int points) async {
+    final uid = _auth.currentUser?.uid;
+    if (uid == null) return;
+    final ref = _firestore.collection('rewards').doc(uid);
+    await _firestore.runTransaction((tx) async {
+      final doc = await tx.get(ref);
+      final current = doc.exists ? (doc.data()?['points'] ?? 0) as int : 0;
+      tx.set(ref, {'points': current + points});
+    });
+  }
+
+  /// Returns a stream of the user's points.
+  Stream<int> watchPoints(String uid) {
+    return _firestore.collection('rewards').doc(uid).snapshots().map((doc) {
+      if (!doc.exists) return 0;
+      return (doc.data()?['points'] ?? 0) as int;
+    });
+  }
+
+  /// Fetches the user's current points once.
+  Future<int> getPoints(String uid) async {
+    final doc = await _firestore.collection('rewards').doc(uid).get();
+    if (!doc.exists) return 0;
+    return (doc.data()?['points'] ?? 0) as int;
+  }
+
+  /// Predefined reward tiers.
+  List<RewardTier> get rewardTiers => const [
+        RewardTier(name: 'Bronze', pointsRequired: 100),
+        RewardTier(name: 'Silver', pointsRequired: 500),
+        RewardTier(name: 'Gold', pointsRequired: 1000),
+      ];
+}


### PR DESCRIPTION
## Summary
- add RewardTier and UserRewards models
- implement RewardsService for point tracking
- introduce RewardsScreen UI
- expose providers for rewards data
- register `/rewards` route

## Testing
- `dart format lib/models/reward_tier.dart lib/models/user_rewards.dart lib/services/rewards_service.dart lib/providers/rewards_provider.dart lib/features/rewards/rewards_screen.dart lib/config/routes.dart`
- `dart test --coverage` *(fails: detected dubious ownership and network access blocks)*

------
https://chatgpt.com/codex/tasks/task_e_685ff55496e08324841eed07e55b24a7