### PR TITLE
Add referral sharing widget

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -35,6 +35,7 @@ import '../features/personal_app/ui/search_screen.dart';
 import '../features/personal_app/ui/content_detail_screen.dart';
 import '../features/personal_app/ui/notifications_screen.dart';
 import '../features/common/ui/error_screen.dart';
+import '../features/referral/referral_screen.dart';
 
 class AppRouter {
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
@@ -196,6 +197,11 @@ class AppRouter {
       case '/invite/list':
         return MaterialPageRoute(
           builder: (_) => const InviteListScreen(),
+          settings: settings,
+        );
+      case '/referral':
+        return MaterialPageRoute(
+          builder: (_) => const ReferralScreen(),
           settings: settings,
         );
       case '/content/:id':

--- a/lib/features/referral/referral_screen.dart
+++ b/lib/features/referral/referral_screen.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../l10n/app_localizations.dart';
+import '../../providers/referral_provider.dart';
+import 'share_invite_widget.dart';
+
+/// Simple screen that displays a referral link using [ShareInviteWidget].
+class ReferralScreen extends ConsumerWidget {
+  const ReferralScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context)!;
+    final referralLinkAsync = ref.watch(referralLinkProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Referral')),
+      body: Center(
+        child: referralLinkAsync.when(
+          data: (link) {
+            if (link == null) {
+              return Text(l10n.errorLoadingInvites);
+            }
+            return ShareInviteWidget(referralLink: link);
+          },
+          loading: () => const CircularProgressIndicator(),
+          error: (_, __) => Text(l10n.errorLoadingInvites),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/referral/share_invite_widget.dart
+++ b/lib/features/referral/share_invite_widget.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:share_plus/share_plus.dart';
+
+/// Widget that displays a simple QR-style placeholder and allows
+/// sharing the referral link using share_plus.
+class ShareInviteWidget extends StatelessWidget {
+  final String referralLink;
+  const ShareInviteWidget({super.key, required this.referralLink});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          height: 200,
+          width: 200,
+          child: CustomPaint(
+            painter: _SimpleQrPainter(referralLink),
+          ),
+        ),
+        const SizedBox(height: 16),
+        ElevatedButton.icon(
+          onPressed: () => Share.share(referralLink),
+          icon: const Icon(Icons.share),
+          label: const Text('Share'),
+        ),
+      ],
+    );
+  }
+}
+
+/// Very small placeholder QR painter based on hashing the data.
+class _SimpleQrPainter extends CustomPainter {
+  final String data;
+  _SimpleQrPainter(this.data);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const modules = 21;
+    final moduleSize = size.width / modules;
+    final paint = Paint()..color = Colors.black;
+    final hash = data.codeUnits.fold<int>(0, (p, c) => p + c);
+    for (var x = 0; x < modules; x++) {
+      for (var y = 0; y < modules; y++) {
+        final index = x * modules + y;
+        if (((hash >> (index % 32)) & 1) == 1) {
+          canvas.drawRect(
+            Rect.fromLTWH(
+                x * moduleSize, y * moduleSize, moduleSize, moduleSize),
+            paint,
+          );
+        }
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}

--- a/lib/providers/referral_provider.dart
+++ b/lib/providers/referral_provider.dart
@@ -1,0 +1,19 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Provides the referral link for the current user if available.
+final referralLinkProvider = FutureProvider<String?>(
+  (ref) async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return null;
+
+    final snap = await FirebaseFirestore.instance
+        .collection('ambassadors')
+        .where('userId', isEqualTo: user.uid)
+        .limit(1)
+        .get();
+    if (snap.docs.isEmpty) return null;
+    return snap.docs.first.data()['shareLink'] as String?;
+  },
+);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   flutter_secure_storage: ^9.0.0
   uni_links: ^0.5.1
   share_plus: ^7.2.1
+  qr_flutter: ^4.1.0
   file_picker: ^6.1.1
   image_picker: ^1.0.7
   google_maps_flutter: 2.6.1

--- a/test/features/referral/referral_screen_test.dart
+++ b/test/features/referral/referral_screen_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:appoint/features/referral/referral_screen.dart';
+import 'package:appoint/features/referral/share_invite_widget.dart';
+import 'package:appoint/providers/referral_provider.dart';
+import '../../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  testWidgets('shows ShareInviteWidget when referral link loads', (tester) async {
+    final container = ProviderContainer(overrides: [
+      referralLinkProvider.overrideWithValue(const AsyncValue.data('link')),
+    ]);
+
+    await tester.pumpWidget(UncontrolledProviderScope(
+      container: container,
+      child: const MaterialApp(home: ReferralScreen()),
+    ));
+    await tester.pump();
+
+    expect(find.byType(ShareInviteWidget), findsOneWidget);
+  });
+}

--- a/test/features/referral/share_invite_widget_test.dart
+++ b/test/features/referral/share_invite_widget_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/features/referral/share_invite_widget.dart';
+import '../../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  testWidgets('renders share button and QR placeholder', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: ShareInviteWidget(referralLink: 'https://example.com'),
+    ));
+
+    expect(find.byType(CustomPaint), findsOneWidget);
+    expect(find.byIcon(Icons.share), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add ShareInviteWidget for sharing referral link
- create ReferralScreen using the new widget
- expose ReferralScreen from router
- provide referral link via new provider
- test ShareInviteWidget and ReferralScreen

## Testing
- `dart test --coverage` *(fails: Dart SDK version conflict)*

------
https://chatgpt.com/codex/tasks/task_e_685ff55e2a788324bd90614182356fc9