### PR TITLE
Add ambassador status to Settings

### DIFF
--- a/lib/features/personal_app/ui/settings_screen.dart
+++ b/lib/features/personal_app/ui/settings_screen.dart
@@ -1,14 +1,57 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:share_plus/share_plus.dart';
 
-class SettingsScreen extends StatelessWidget {
+import '../../../providers/ambassador_record_provider.dart';
+
+class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ambassadorAsync = ref.watch(ambassadorRecordProvider);
+
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
-      body: const Center(
-        child: Text('Settings Screen'),
+      body: ambassadorAsync.when(
+        data: (ambassador) {
+          if (ambassador == null) {
+            return Center(
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.pushNamed(context, '/ambassador-onboarding');
+                },
+                child: const Text('Become an Ambassador'),
+              ),
+            );
+          }
+
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Ambassador Status: ${ambassador.status}'),
+                const SizedBox(height: 8),
+                Text('Referrals: ${ambassador.referrals}'),
+                const SizedBox(height: 8),
+                SelectableText(ambassador.shareLink),
+                const SizedBox(height: 8),
+                ElevatedButton.icon(
+                  icon: const Icon(Icons.share),
+                  onPressed: () {
+                    Share.share(
+                      'Join me on Appoint! Use my ambassador link: ${ambassador.shareLink}',
+                    );
+                  },
+                  label: const Text('Share Link'),
+                ),
+              ],
+            ),
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
       ),
     );
   }

--- a/lib/models/ambassador_record.dart
+++ b/lib/models/ambassador_record.dart
@@ -1,0 +1,29 @@
+class AmbassadorRecord {
+  final String id;
+  final String status;
+  final String shareLink;
+  final int referrals;
+
+  AmbassadorRecord({
+    required this.id,
+    required this.status,
+    required this.shareLink,
+    required this.referrals,
+  });
+
+  factory AmbassadorRecord.fromJson(Map<String, dynamic> json) {
+    return AmbassadorRecord(
+      id: json['id'] as String,
+      status: json['status'] as String? ?? 'inactive',
+      shareLink: json['shareLink'] as String? ?? '',
+      referrals: (json['referrals'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'status': status,
+        'shareLink': shareLink,
+        'referrals': referrals,
+      };
+}

--- a/lib/providers/ambassador_record_provider.dart
+++ b/lib/providers/ambassador_record_provider.dart
@@ -1,0 +1,18 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/ambassador_record.dart';
+
+final ambassadorRecordProvider = FutureProvider<AmbassadorRecord?>((ref) async {
+  final uid = FirebaseAuth.instance.currentUser?.uid;
+  if (uid == null) return null;
+  final snap = await FirebaseFirestore.instance
+      .collection('ambassadors')
+      .where('userId', isEqualTo: uid)
+      .limit(1)
+      .get();
+  if (snap.docs.isEmpty) return null;
+  final doc = snap.docs.first;
+  return AmbassadorRecord.fromJson({'id': doc.id, ...doc.data()});
+});


### PR DESCRIPTION
## Summary
- show ambassador status on settings screen
- add provider/model to fetch ambassador record

## Testing
- `dart pub get` *(fails: Dart SDK version 3.3.0 < required 3.4.0)*

------
https://chatgpt.com/codex/tasks/task_e_685ff56794c08324b5cca1458390a548