### PR TITLE
Add localization contribution tooling

### DIFF
--- a/lib/features/localization/localization_contribution_screen.dart
+++ b/lib/features/localization/localization_contribution_screen.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import '../../l10n/l10n_contribution.dart';
+
+/// Simple UI allowing ambassadors to submit missing translations.
+class LocalizationContributionScreen extends StatefulWidget {
+  const LocalizationContributionScreen({super.key});
+
+  @override
+  State<LocalizationContributionScreen> createState() =>
+      _LocalizationContributionScreenState();
+}
+
+class _LocalizationContributionScreenState
+    extends State<LocalizationContributionScreen> {
+  String? _selectedLocale;
+
+  @override
+  Widget build(BuildContext context) {
+    final locales = missingTranslations.keys.toList()..sort();
+    _selectedLocale ??= locales.isNotEmpty ? locales.first : null;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Localization Contribution'),
+      ),
+      body: _selectedLocale == null
+          ? const Center(child: Text('No missing translations'))
+          : Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: DropdownButton<String>(
+                    value: _selectedLocale,
+                    onChanged: (val) => setState(() => _selectedLocale = val),
+                    items: [
+                      for (final locale in locales)
+                        DropdownMenuItem(
+                          value: locale,
+                          child: Text(locale),
+                        )
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: ListView(
+                    padding: const EdgeInsets.all(16),
+                    children: [
+                      for (final key in missingTranslations[_selectedLocale]!)
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 8),
+                          child: TextField(
+                            decoration: InputDecoration(
+                              labelText: key,
+                              border: const OutlineInputBorder(),
+                            ),
+                          ),
+                        ),
+                      const SizedBox(height: 16),
+                      ElevatedButton(
+                        onPressed: () {
+                          // TODO: send translations to backend
+                        },
+                        child: const Text('Submit'),
+                      ),
+                    ],
+                  ),
+                )
+              ],
+            ),
+    );
+  }
+}

--- a/lib/l10n/l10n_contribution.dart
+++ b/lib/l10n/l10n_contribution.dart
@@ -1,0 +1,2 @@
+const Map<String, List<String>> missingTranslations = {
+};


### PR DESCRIPTION
## Summary
- generate `l10n_contribution.dart` showing missing translation keys
- scaffold basic UI for ambassadors to submit translations

## Testing
- `dart scripts/merge_l10n.dart` *(fails: `fatal: detected dubious ownership` but generates file)*
- `dart test --coverage` *(fails: storage.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685ff57012b883248bd1dc2c10e45bc0