### PR TITLE
Update README for development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,3 +236,16 @@ Our GitHub Actions pipeline (`.github/workflows/flutter.yml`) runs on every push
 - ⚠️ iOS setup requires manual configuration (bundle ID, GoogleService-Info.plist)
 
 **Note**: Localization and language files were excluded from this update round as requested.
+
+## Development Setup
+
+- **Flutter/Dart Versions**: Flutter 3.32.0 with Dart 3.4.0 is required.
+- **Initial Script**: Run `./setup.sh` once after cloning to install dependencies.
+- **CI Network Allowlist**: Ensure your CI runners can access `storage.googleapis.com`, `firebase-public.firebaseio.com`, `metadata.google.internal`, `169.254.169.254`, `raw.githubusercontent.com`, and `pub.dev`.
+- **Code Generation**: Use `./tool/codegen.sh` to run build_runner when models or localization files change.
+- **Running Tests**:
+  ```bash
+  firebase emulators:start --only auth,firestore
+  dart test --coverage
+  flutter test --coverage
+  ```


### PR DESCRIPTION
## Summary
- document development setup for Flutter 3.32.0 / Dart 3.4.0

## Testing
- `flutter pub get` *(fails: domain storage.googleapis.com blocked)*
- `dart test --coverage` *(fails: domain storage.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685ff58278748324b4718a4cae18cda1