### PR TITLE
Implement referral code generation

### DIFF
--- a/lib/features/referral/referral_screen.dart
+++ b/lib/features/referral/referral_screen.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/referral_provider.dart';
+
+class ReferralScreen extends ConsumerWidget {
+  const ReferralScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final codeAsync = ref.watch(referralCodeProvider);
+    final usageAsync = ref.watch(referralUsageProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Referral')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: codeAsync.when(
+          data: (code) => Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text('Your Referral Code'),
+              SelectableText(
+                code,
+                style: Theme.of(context).textTheme.headlineMedium,
+              ),
+              const SizedBox(height: 16),
+              Row(
+                children: [
+                  ElevatedButton(
+                    onPressed: () {
+                      Clipboard.setData(ClipboardData(text: code));
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Copied to clipboard')),
+                      );
+                    },
+                    child: const Text('Copy'),
+                  ),
+                  const SizedBox(width: 16),
+                  ElevatedButton(
+                    onPressed: () {
+                      Share.share('Use my referral code: $code');
+                    },
+                    child: const Text('Share'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              usageAsync.when(
+                data: (count) => Text('Used $count times'),
+                loading: () => const CircularProgressIndicator(),
+                error: (_, __) => const SizedBox.shrink(),
+              ),
+            ],
+          ),
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (_, __) => const Center(child: Text('Error generating code')),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/providers/referral_provider.dart
+++ b/lib/providers/referral_provider.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../services/referral_service.dart';
+
+final referralServiceProvider = Provider<ReferralService>((ref) {
+  return ReferralService();
+});
+
+final referralCodeProvider = FutureProvider<String>((ref) {
+  return ref.read(referralServiceProvider).generateReferralCode();
+});
+
+final referralUsageProvider = StreamProvider<int>((ref) {
+  return ref.read(referralServiceProvider).listenToReferralUsage();
+});

--- a/lib/services/referral_service.dart
+++ b/lib/services/referral_service.dart
@@ -1,0 +1,62 @@
+import 'dart:math';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class ReferralService {
+  final FirebaseFirestore _firestore;
+  final FirebaseAuth _auth;
+
+  ReferralService({FirebaseFirestore? firestore, FirebaseAuth? auth})
+      : _firestore = firestore ?? FirebaseFirestore.instance,
+        _auth = auth ?? FirebaseAuth.instance;
+
+  /// Generates a referral code for the currently signed in user.
+  /// If a code already exists it will be returned instead of creating a new one.
+  Future<String> generateReferralCode() async {
+    final user = _auth.currentUser;
+    if (user == null) throw Exception('No authenticated user');
+
+    final docRef = _firestore.collection('referralCodes').doc(user.uid);
+    final existing = await docRef.get();
+    if (existing.exists && existing.data()?['code'] != null) {
+      return existing.data()!['code'] as String;
+    }
+
+    String code;
+    do {
+      code = _randomCode();
+      final query = await _firestore
+          .collection('referralCodes')
+          .where('code', isEqualTo: code)
+          .limit(1)
+          .get();
+      if (query.docs.isEmpty) break;
+    } while (true);
+
+    await docRef.set({
+      'code': code,
+      'usageCount': 0,
+      'createdAt': FieldValue.serverTimestamp(),
+    });
+    return code;
+  }
+
+  /// Listens to changes in the current user's referral usage count.
+  Stream<int> listenToReferralUsage() {
+    final user = _auth.currentUser;
+    if (user == null) return const Stream<int>.empty();
+    return _firestore
+        .collection('referralCodes')
+        .doc(user.uid)
+        .snapshots()
+        .map((snap) => (snap.data()?['usageCount'] ?? 0) as int);
+  }
+
+  String _randomCode([int length = 6]) {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    final rand = Random.secure();
+    return List.generate(length, (_) => chars[rand.nextInt(chars.length)])
+        .join();
+  }
+}

--- a/test/referral_service_test.dart
+++ b/test/referral_service_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:appoint/services/referral_service.dart';
+import 'fake_firebase_firestore.dart';
+import 'fake_firebase_setup.dart';
+
+class FakeUser extends Fake implements User {
+  @override
+  final String uid;
+  FakeUser(this.uid);
+}
+
+class FakeAuth extends Fake implements FirebaseAuth {
+  FakeAuth(this._user);
+  final User? _user;
+  @override
+  User? get currentUser => _user;
+}
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  group('ReferralService', () {
+    late FakeFirebaseFirestore firestore;
+    late FakeAuth auth;
+    late ReferralService service;
+
+    setUp(() {
+      firestore = FakeFirebaseFirestore();
+      auth = FakeAuth(FakeUser('u1'));
+      service = ReferralService(firestore: firestore, auth: auth);
+    });
+
+    test('generateReferralCode stores code in firestore', () async {
+      final code = await service.generateReferralCode();
+      final snap = await firestore.collection('referralCodes').doc('u1').get();
+      expect(snap.data()?['code'], code);
+    });
+
+    test('generateReferralCode returns existing code', () async {
+      final first = await service.generateReferralCode();
+      final second = await service.generateReferralCode();
+      expect(second, first);
+    });
+
+    test('listenToReferralUsage emits updates', () async {
+      await service.generateReferralCode();
+      final stream = service.listenToReferralUsage();
+      expectLater(stream, emitsInOrder([0, 2]));
+      await firestore
+          .collection('referralCodes')
+          .doc('u1')
+          .update({'usageCount': 2});
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add ReferralService for generating unique referral codes stored in Firestore
- expose providers for referral code and usage
- scaffold ReferralScreen to show, copy and share the code
- add unit tests for ReferralService

## Testing
- `dart pub get` *(fails: storage.googleapis.com blocked)*
- `dart test --coverage` *(fails: requires Dart SDK >=3.4.0)*

------
https://chatgpt.com/codex/tasks/task_e_685ff602d2d08324a077d112e840880b