### PR TITLE
Fix Flutter & Dart in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,16 @@ jobs:
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.20.0'
-      - name: Add Flutter to PATH
-        run: echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+          flutter-version: '3.32.0'
+      - name: Setup Dart SDK
+        uses: actions/setup-dart@v3
+        with:
+          dart-version: '3.4.0'
+      - name: Add Flutter & Dart to PATH
+        run: |
+          echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+          echo "$HOME/.dart-sdk/bin" >> $GITHUB_PATH
+          echo "$HOME/.flutter/bin/cache/dart-sdk/bin" >> $GITHUB_PATH
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:
@@ -132,9 +139,16 @@ jobs:
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.20.0'
-      - name: Add Flutter to PATH
-        run: echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+          flutter-version: '3.32.0'
+      - name: Setup Dart SDK
+        uses: actions/setup-dart@v3
+        with:
+          dart-version: '3.4.0'
+      - name: Add Flutter & Dart to PATH
+        run: |
+          echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+          echo "$HOME/.dart-sdk/bin" >> $GITHUB_PATH
+          echo "$HOME/.flutter/bin/cache/dart-sdk/bin" >> $GITHUB_PATH
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:
@@ -209,9 +223,16 @@ jobs:
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.20.0'
-      - name: Add Flutter to PATH
-        run: echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+          flutter-version: '3.32.0'
+      - name: Setup Dart SDK
+        uses: actions/setup-dart@v3
+        with:
+          dart-version: '3.4.0'
+      - name: Add Flutter & Dart to PATH
+        run: |
+          echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+          echo "$HOME/.dart-sdk/bin" >> $GITHUB_PATH
+          echo "$HOME/.flutter/bin/cache/dart-sdk/bin" >> $GITHUB_PATH
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:
@@ -270,9 +291,16 @@ jobs:
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.20.0'
-      - name: Add Flutter to PATH
-        run: echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+          flutter-version: '3.32.0'
+      - name: Setup Dart SDK
+        uses: actions/setup-dart@v3
+        with:
+          dart-version: '3.4.0'
+      - name: Add Flutter & Dart to PATH
+        run: |
+          echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+          echo "$HOME/.dart-sdk/bin" >> $GITHUB_PATH
+          echo "$HOME/.flutter/bin/cache/dart-sdk/bin" >> $GITHUB_PATH
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:
@@ -354,9 +382,16 @@ jobs:
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.20.0'
-      - name: Add Flutter to PATH
-        run: echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+          flutter-version: '3.32.0'
+      - name: Setup Dart SDK
+        uses: actions/setup-dart@v3
+        with:
+          dart-version: '3.4.0'
+      - name: Add Flutter & Dart to PATH
+        run: |
+          echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+          echo "$HOME/.dart-sdk/bin" >> $GITHUB_PATH
+          echo "$HOME/.flutter/bin/cache/dart-sdk/bin" >> $GITHUB_PATH
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:
@@ -437,9 +472,16 @@ jobs:
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.20.0'
-      - name: Add Flutter to PATH
-        run: echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+          flutter-version: '3.32.0'
+      - name: Setup Dart SDK
+        uses: actions/setup-dart@v3
+        with:
+          dart-version: '3.4.0'
+      - name: Add Flutter & Dart to PATH
+        run: |
+          echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+          echo "$HOME/.dart-sdk/bin" >> $GITHUB_PATH
+          echo "$HOME/.flutter/bin/cache/dart-sdk/bin" >> $GITHUB_PATH
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:
@@ -520,9 +562,16 @@ jobs:
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.20.0'
-      - name: Add Flutter to PATH
-        run: echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+          flutter-version: '3.32.0'
+      - name: Setup Dart SDK
+        uses: actions/setup-dart@v3
+        with:
+          dart-version: '3.4.0'
+      - name: Add Flutter & Dart to PATH
+        run: |
+          echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+          echo "$HOME/.dart-sdk/bin" >> $GITHUB_PATH
+          echo "$HOME/.flutter/bin/cache/dart-sdk/bin" >> $GITHUB_PATH
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -28,9 +28,14 @@ jobs:
         with:
           flutter-version: '3.32.0'
           cache: true
+      - name: Setup Dart SDK
+        uses: actions/setup-dart@v3
+        with:
+          dart-version: '3.4.0'
       - name: Ensure Flutter & Dart in PATH
         run: |
           echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+          echo "$HOME/.dart-sdk/bin" >> $GITHUB_PATH
           echo "$HOME/.flutter/bin/cache/dart-sdk/bin" >> $GITHUB_PATH
       - name: Cache Pub packages
         uses: actions/cache@v3

--- a/.github/workflows/flutter_web.yml
+++ b/.github/workflows/flutter_web.yml
@@ -26,8 +26,15 @@ jobs:
       with:
         flutter-version: '3.32.0'
         cache: true
-    - name: Ensure flutter in PATH
-      run: echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+    - name: Setup Dart SDK
+      uses: actions/setup-dart@v3
+      with:
+        dart-version: '3.4.0'
+    - name: Ensure flutter & dart in PATH
+      run: |
+        echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+        echo "$HOME/.dart-sdk/bin" >> $GITHUB_PATH
+        echo "$HOME/.flutter/bin/cache/dart-sdk/bin" >> $GITHUB_PATH
     - name: Cache Pub packages
       uses: actions/cache@v3
       with:

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -17,11 +17,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Flutter SDK
-        uses: flutter-actions/setup-flutter@v2
+        uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.20.0'
-      - name: Ensure flutter in PATH
-        run: echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+          flutter-version: '3.32.0'
+      - name: Setup Dart SDK
+        uses: actions/setup-dart@v3
+        with:
+          dart-version: '3.4.0'
+      - name: Ensure Flutter & Dart in PATH
+        run: |
+          echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+          echo "$HOME/.dart-sdk/bin" >> $GITHUB_PATH
+          echo "$HOME/.flutter/bin/cache/dart-sdk/bin" >> $GITHUB_PATH
       - name: Cache Pub packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -22,8 +22,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.20.0'
-      - run: echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+          flutter-version: '3.32.0'
+      - uses: actions/setup-dart@v3
+        with:
+          dart-version: '3.4.0'
+      - run: |
+          echo "$HOME/.flutter/bin" >> $GITHUB_PATH
+          echo "$HOME/.dart-sdk/bin" >> $GITHUB_PATH
+          echo "$HOME/.flutter/bin/cache/dart-sdk/bin" >> $GITHUB_PATH
+      - run: flutter --version
+      - run: dart --version
       - run: flutter pub get
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs


### PR DESCRIPTION
## Summary
- install Flutter 3.32.0 and Dart 3.4.0 in CI
- update CI YAML files to include both tools in PATH
- verify versions before running `flutter pub get` and `dart pub get`

## Testing
- `dart test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff6b0d2b48324868b1d88730065ca