### PR TITLE
Use Firebase Storage emulator in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,8 @@ jobs:
           fi
       - name: Start Firebase emulators
         run: |
-          (firebase emulators:start --only firestore,auth || sleep 5 && firebase emulators:start --only firestore,auth) &
+          export FIREBASE_STORAGE_EMULATOR_HOST="localhost:9199"
+          (firebase emulators:start --only firestore,auth,storage || sleep 5 && firebase emulators:start --only firestore,auth,storage) &
           echo $! > emulator.pid
       - run: flutter pub downgrade || true
       - name: Run tests with coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,9 @@ flutter run -d chrome      # Web
 ## Testing
 
 ```bash
-# Start Firebase emulators for Auth & Firestore
-firebase emulators:start --only auth,firestore
+# Start Firebase emulators for Auth, Firestore & Storage
+export FIREBASE_STORAGE_EMULATOR_HOST="localhost:9199"
+firebase emulators:start --only auth,firestore,storage
 
 # From project root:
 dart test --coverage

--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ dart test --coverage
 
 # Firebase emulators
 # (Download emulator JAR manually if 403, place under ~/.config/firebase/emulators/)
-firebase emulators:start --only auth,firestore
+export FIREBASE_STORAGE_EMULATOR_HOST="localhost:9199"
+firebase emulators:start --only auth,firestore,storage
 ```
 
 

--- a/TESTING_AND_DEPLOYMENT.md
+++ b/TESTING_AND_DEPLOYMENT.md
@@ -2,6 +2,12 @@
 
 ## Unit
 Run `scripts/run_tests.sh unit` to execute unit tests.
+Ensure the Firebase emulator suite is running with Storage enabled:
+
+```bash
+export FIREBASE_STORAGE_EMULATOR_HOST="localhost:9199"
+firebase emulators:start --only auth,firestore,storage &
+```
 
 ## Integration
 Run `scripts/run_tests.sh integration` to execute integration tests.

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,2 +1,2 @@
 test:
-  pre_test: test/test_config.dart
+  pre_test: test/test_setup_init.dart

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+import 'package:firebase_storage/firebase_storage.dart';
+
+/// Simple wrapper around [FirebaseStorage] that connects to the emulator
+/// when running in tests.
+class StorageService {
+  final FirebaseStorage _storage;
+
+  StorageService({FirebaseStorage? storage})
+      : _storage = storage ?? FirebaseStorage.instance {
+    _connectToEmulatorIfNeeded();
+  }
+
+  void _connectToEmulatorIfNeeded() {
+    const bool isTest =
+        bool.fromEnvironment('FLUTTER_TEST', defaultValue: false);
+    final host = Platform.environment['FIREBASE_STORAGE_EMULATOR_HOST'];
+    if (isTest && host != null && host.contains(':')) {
+      final parts = host.split(':');
+      final port = int.tryParse(parts[1]) ?? 9199;
+      _storage.useStorageEmulator(parts[0], port);
+    }
+  }
+
+  Future<String> uploadFile(File file, String path) async {
+    final ref = _storage.ref().child(path);
+    await ref.putFile(file);
+    return ref.getDownloadURL();
+  }
+}

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -4,6 +4,7 @@ MODE="$1"
 
 case "$MODE" in
   unit)
+    export FIREBASE_STORAGE_EMULATOR_HOST="localhost:9199"
     if command -v dart >/dev/null 2>&1; then
       dart test --coverage
     else
@@ -11,7 +12,8 @@ case "$MODE" in
     fi
     ;;
   integration)
-    npx firebase emulators:start --only firestore,functions --project "$FIREBASE_PROJECT" --import=./emulator_data &
+    export FIREBASE_STORAGE_EMULATOR_HOST="localhost:9199"
+    npx firebase emulators:start --only firestore,functions,storage --project "$FIREBASE_PROJECT" --import=./emulator_data &
     EMULATOR_PID=$!
     sleep 5
     if command -v dart >/dev/null 2>&1; then
@@ -22,7 +24,8 @@ case "$MODE" in
     kill $EMULATOR_PID
     ;;
   all|*)
-    npx firebase emulators:start --only firestore,functions --project "$FIREBASE_PROJECT" --import=./emulator_data &
+    export FIREBASE_STORAGE_EMULATOR_HOST="localhost:9199"
+    npx firebase emulators:start --only firestore,functions,storage --project "$FIREBASE_PROJECT" --import=./emulator_data &
     EMULATOR_PID=$!
     sleep 5
     if command -v dart >/dev/null 2>&1; then

--- a/test/test_setup_init.dart
+++ b/test/test_setup_init.dart
@@ -1,0 +1,10 @@
+import 'package:firebase_storage/firebase_storage.dart';
+import 'test_config.dart';
+
+/// Initializes Firebase and configures the storage emulator before tests run.
+Future<void> main() async {
+  setupTestConfig();
+
+  // Connect Firebase Storage to the local emulator.
+  FirebaseStorage.instance.useStorageEmulator('localhost', 9199);
+}


### PR DESCRIPTION
## Summary
- connect StorageService to the emulator when running tests
- initialize storage emulator in test setup
- start emulator with storage in CI and local scripts
- document the FIREBASE_STORAGE_EMULATOR_HOST variable for running tests

## Testing
- `dart test --coverage` *(fails: The current Dart SDK version is 3.3.0. Because appoint requires SDK version >=3.4.0 <4.0.0, version solving failed.)*


------
https://chatgpt.com/codex/tasks/task_e_685ff7ef09988324bd75ed96beadcd23