### PR TITLE
Update Dart SDK constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
+  sdk: ">=3.4.0 <4.0.0"
   flutter: ">=3.19.0"
 
 dependencies:


### PR DESCRIPTION
## Summary
- raise min Dart SDK version to 3.4.0 in `pubspec.yaml`

## Testing
- `flutter --version` *(fails: command not found)*
- `/workspace/flutter_sdk/bin/flutter pub get` *(fails due to Dart 3.3.0 and blocked network requests)*

------
https://chatgpt.com/codex/tasks/task_e_685ff89c8fcc83249c447ad02684c915