### PR TITLE
Add rewards system

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -36,6 +36,7 @@ import '../features/personal_app/ui/content_detail_screen.dart';
 import '../features/personal_app/ui/notifications_screen.dart';
 import '../features/common/ui/error_screen.dart';
 import '../features/referral/referral_screen.dart';
+import '../features/rewards/rewards_screen.dart';
 
 class AppRouter {
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
@@ -202,6 +203,11 @@ class AppRouter {
       case '/referral':
         return MaterialPageRoute(
           builder: (_) => const ReferralScreen(),
+          settings: settings,
+        );
+      case '/rewards':
+        return MaterialPageRoute(
+          builder: (_) => const RewardsScreen(),
           settings: settings,
         );
       case '/content/:id':

--- a/lib/features/rewards/rewards_screen.dart
+++ b/lib/features/rewards/rewards_screen.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/rewards_provider.dart';
+
+class RewardsScreen extends ConsumerWidget {
+  const RewardsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final pointsAsync = ref.watch(userPointsProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Rewards')),
+      body: pointsAsync.when(
+        data: (points) {
+          final tier = ref.read(rewardsServiceProvider).tierForPoints(points);
+          final nextTier = _nextTierInfo(points);
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Points: $points',
+                  style: Theme.of(context).textTheme.headlineMedium,
+                ),
+                const SizedBox(height: 8),
+                Text('Current Tier: ${tier.toUpperCase()}'),
+                if (nextTier != null) ...[
+                  const SizedBox(height: 8),
+                  Text(
+                      'Next Tier (${nextTier['tier']}) at ${nextTier['points']} points'),
+                ],
+              ],
+            ),
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, __) => const Center(child: Text('Error loading rewards')),
+      ),
+    );
+  }
+
+  Map<String, dynamic>? _nextTierInfo(int points) {
+    if (points < RewardsService.rewardTiers['silver']!) {
+      return {
+        'tier': 'silver',
+        'points': RewardsService.rewardTiers['silver'],
+      };
+    }
+    if (points < RewardsService.rewardTiers['gold']!) {
+      return {
+        'tier': 'gold',
+        'points': RewardsService.rewardTiers['gold'],
+      };
+    }
+    return null;
+  }
+}

--- a/lib/providers/rewards_provider.dart
+++ b/lib/providers/rewards_provider.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/rewards_service.dart';
+import 'auth_provider.dart';
+
+final rewardsServiceProvider =
+    Provider<RewardsService>((ref) => RewardsService());
+
+final userPointsProvider = StreamProvider<int>((ref) {
+  final authState = ref.watch(authStateProvider);
+  return authState.when(
+    data: (user) {
+      if (user == null) {
+        return const Stream.empty();
+      }
+      return ref.read(rewardsServiceProvider).watchPoints(user.uid);
+    },
+    loading: () => const Stream.empty(),
+    error: (_, __) => const Stream.empty(),
+  );
+});

--- a/lib/services/rewards_service.dart
+++ b/lib/services/rewards_service.dart
@@ -1,0 +1,59 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class RewardsService {
+  final FirebaseFirestore _firestore;
+  final FirebaseAuth _auth;
+
+  RewardsService({FirebaseFirestore? firestore, FirebaseAuth? auth})
+      : _firestore = firestore ?? FirebaseFirestore.instance,
+        _auth = auth ?? FirebaseAuth.instance;
+
+  /// Points awarded when a referral signs up.
+  static const int referralSignupPoints = 10;
+
+  /// Reward tier thresholds.
+  static const Map<String, int> rewardTiers = {
+    'bronze': 0,
+    'silver': 100,
+    'gold': 500,
+  };
+
+  /// Increment the current user's points when a referral signs up.
+  Future<int> addReferralSignupPoints(String referrerId) async {
+    return _incrementPoints(referrerId, referralSignupPoints);
+  }
+
+  /// Get the current point balance for a user.
+  Future<int> getPoints(String userId) async {
+    final doc = await _firestore.collection('user_rewards').doc(userId).get();
+    return (doc.data()?['points'] as int?) ?? 0;
+  }
+
+  /// Stream the point balance for a user.
+  Stream<int> watchPoints(String userId) {
+    return _firestore
+        .collection('user_rewards')
+        .doc(userId)
+        .snapshots()
+        .map((doc) => (doc.data()?['points'] as int?) ?? 0);
+  }
+
+  /// Determine the reward tier for a given point balance.
+  String tierForPoints(int points) {
+    if (points >= rewardTiers['gold']!) return 'gold';
+    if (points >= rewardTiers['silver']!) return 'silver';
+    return 'bronze';
+  }
+
+  Future<int> _incrementPoints(String userId, int points) async {
+    final doc = _firestore.collection('user_rewards').doc(userId);
+    return _firestore.runTransaction((tx) async {
+      final snapshot = await tx.get(doc);
+      final current = (snapshot.data()?['points'] as int?) ?? 0;
+      final updated = current + points;
+      tx.set(doc, {'points': updated}, SetOptions(merge: true));
+      return updated;
+    });
+  }
+}

--- a/test/services/rewards_service_test.dart
+++ b/test/services/rewards_service_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/services/rewards_service.dart';
+import '../fake_firebase_setup.dart';
+import '../fake_firebase_firestore.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  group('RewardsService', () {
+    late RewardsService service;
+    late FakeFirebaseFirestore firestore;
+
+    setUp(() {
+      firestore = FakeFirebaseFirestore();
+      service = RewardsService(firestore: firestore);
+    });
+
+    test('addReferralSignupPoints increments points', () async {
+      final userId = 'user1';
+      var points = await service.getPoints(userId);
+      expect(points, 0);
+
+      await service.addReferralSignupPoints(userId);
+      points = await service.getPoints(userId);
+      expect(points, RewardsService.referralSignupPoints);
+    });
+
+    test('multiple increments accumulate', () async {
+      final userId = 'user2';
+      await service.addReferralSignupPoints(userId);
+      await service.addReferralSignupPoints(userId);
+
+      final points = await service.getPoints(userId);
+      expect(points, RewardsService.referralSignupPoints * 2);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- create `RewardsService` for tracking points in Firestore
- expose `rewardsServiceProvider` and `userPointsProvider`
- add rewards screen
- register `/rewards` route
- test RewardsService point increment logic

## Testing
- `dart test --coverage` *(fails: version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_685ff968f4ac832485b95c0565fac62f