### PR TITLE
Fix routes and add rewards screen

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -36,6 +36,7 @@ import '../features/personal_app/ui/content_detail_screen.dart';
 import '../features/personal_app/ui/notifications_screen.dart';
 import '../features/common/ui/error_screen.dart';
 import '../features/referral/referral_screen.dart';
+import '../features/rewards/rewards_screen.dart';
 
 class AppRouter {
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
@@ -197,6 +198,11 @@ class AppRouter {
       case '/invite/list':
         return MaterialPageRoute(
           builder: (_) => const InviteListScreen(),
+          settings: settings,
+        );
+      case '/rewards':
+        return MaterialPageRoute(
+          builder: (_) => const RewardsScreen(),
           settings: settings,
         );
       case '/referral':

--- a/lib/features/rewards/rewards_screen.dart
+++ b/lib/features/rewards/rewards_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class RewardsScreen extends StatelessWidget {
+  const RewardsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Rewards')),
+      body: const Center(
+        child: Text('Rewards Screen Placeholder'),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add placeholder RewardsScreen
- import RewardsScreen and register /rewards route
- keep /referral route

## Testing
- `flutter pub get` *(fails: firebase_remote_config depends on firebase_core ^3.14.0)*
- `dart test --coverage` *(fails: version solving failed for firebase_remote_config)*

------
https://chatgpt.com/codex/tasks/task_e_685ffbcd53b88324b4c9c8e321a4ebee