### PR TITLE
Add Dart 3.4 dev container build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:22.04
+
+# Install dependencies for Dart installation
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget unzip ca-certificates xz-utils && \
+    rm -rf /var/lib/apt/lists/*
+
+# Download and install Dart SDK 3.4.0
+RUN wget -O /tmp/dart-sdk.zip https://storage.googleapis.com/dart-archive/channels/stable/release/3.4.0/sdk/dartsdk-linux-x64-release.zip && \
+    unzip /tmp/dart-sdk.zip -d /usr/local && \
+    mv /usr/local/dart-sdk /usr/local/dart && \
+    rm /tmp/dart-sdk.zip
+
+# Set PATH for Dart
+ENV PATH="/usr/local/dart/bin:${PATH}"
+
+# Verify installation
+RUN dart --version
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,9 @@
 {
   "name": "Flutter App",
-  "image": "dart:3.4",
-  "postCreateCommand": "dart pub get",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "postCreateCommand": "dart --version && dart pub get",
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
## Summary
- add Dockerfile installing Dart SDK 3.4.0 explicitly
- update devcontainer to build from Dockerfile and print Dart version on create

## Testing
- `flutter pub get`
- `firebase emulators:start --only auth,firestore` *(fails: command not found)*
- `dart test --coverage` *(fails: Flutter SDK requirement unsatisfied)*
- `dart --version`


------
https://chatgpt.com/codex/tasks/task_e_685ffbd6c66c83249e6fb599e8271fe9