### PR TITLE
Add integration_test dev dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,6 +61,7 @@ dev_dependencies:
   fake_cloud_firestore: ^2.4.0
   firebase_auth_mocks: ^0.13.0
   mockito: ^5.4.2
+  integration_test: ^1.0.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- include `integration_test` in `pubspec.yaml`
- attempted to run `dart pub get` and `flutter test integration_test`

## Testing
- `dart pub get` *(fails: firebase_remote_config >=5.4.5 depends on firebase_core ^3.14.0)*
- `flutter test --no-pub integration_test` *(fails: cannot run without package:flutter_test or package:test)*

------
https://chatgpt.com/codex/tasks/task_e_685ffbdfe7208324ad2c735ac7dc81d4