### PR TITLE
Add HTTP overrides for tests

### DIFF
--- a/test/test_config.dart
+++ b/test/test_config.dart
@@ -1,11 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_core_platform_interface/test.dart';
+import 'test_setup_init.dart';
 
 /// Ensures the widget binding is initialized and Firebase core mocks are set up
 /// before running tests.
 void setupTestConfig() {
   TestWidgetsFlutterBinding.ensureInitialized();
   setupFirebaseCoreMocks();
+  initializeHttpOverrides();
 }
 
 void main() {

--- a/test/test_setup_init.dart
+++ b/test/test_setup_init.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+
+/// HTTP overrides for tests to prevent requests to external hosts.
+class TestHttpOverrides extends HttpOverrides {
+  /// Mapping from blocked hosts to the local emulator host.
+  final String emulatorHost;
+  final int emulatorPort;
+
+  TestHttpOverrides({this.emulatorHost = 'localhost', this.emulatorPort = 8080});
+
+  @override
+  HttpClient createHttpClient(SecurityContext? context) {
+    return _InterceptingHttpClient(emulatorHost, emulatorPort);
+  }
+}
+
+class _InterceptingHttpClient extends HttpClient {
+  final String emulatorHost;
+  final int emulatorPort;
+
+  _InterceptingHttpClient(this.emulatorHost, this.emulatorPort);
+
+  static const _blockedHosts = {
+    'storage.googleapis.com',
+    'firebase-public.firebaseio.com',
+    'metadata.google.internal',
+    '169.254.169.254',
+  };
+
+  Uri _redirect(Uri url) {
+    if (_blockedHosts.contains(url.host)) {
+      return url.replace(host: emulatorHost, port: emulatorPort, scheme: 'http');
+    }
+    return url;
+  }
+
+  @override
+  Future<HttpClientRequest> openUrl(String method, Uri url) {
+    return super.openUrl(method, _redirect(url));
+  }
+}
+
+/// Sets [HttpOverrides.global] to [TestHttpOverrides].
+void initializeHttpOverrides({String host = 'localhost', int port = 8080}) {
+  HttpOverrides.global = TestHttpOverrides(emulatorHost: host, emulatorPort: port);
+}


### PR DESCRIPTION
## Summary
- block external network calls during tests by adding `TestHttpOverrides`
- initialize the overrides in test setup

## Testing
- `firebase emulators:start --only auth,firestore` *(fails: command not found)*
- `dart test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ffbf4193c83249b9f318fec427bf3