### PR TITLE
Update pubspec environment and dev dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,6 @@ version: 1.0.0+1
 
 environment:
   sdk: ">=3.4.0 <4.0.0"
-  flutter: ">=3.19.0"
 
 dependencies:
   flutter:
@@ -62,6 +61,7 @@ dev_dependencies:
   firebase_auth_mocks: ^0.13.0
   mockito: ^5.4.2
   test: ^1.31.0
+  integration_test: ^1.0.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- remove flutter constraint line under environment
- add integration_test dev dependency

## Testing
- `flutter pub get` *(fails: The current Dart SDK version is 3.3.0)*
- `dart test --coverage` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686007a692bc8324bfc60bb04db93c81