### PR TITLE
Add Dart 3.4 install steps in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,12 +1,14 @@
 FROM ubuntu:22.04
 
+ARG DART_VERSION=3.4.0
+
 # Install dependencies for Dart installation
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget unzip ca-certificates xz-utils && \
     rm -rf /var/lib/apt/lists/*
 
-# Download and install Dart SDK 3.4.0
-RUN wget -O /tmp/dart-sdk.zip https://storage.googleapis.com/dart-archive/channels/stable/release/3.4.0/sdk/dartsdk-linux-x64-release.zip && \
+# Download and install Dart SDK
+RUN wget -O /tmp/dart-sdk.zip https://storage.googleapis.com/dart-archive/channels/stable/release/${DART_VERSION}/sdk/dartsdk-linux-x64-release.zip && \
     unzip /tmp/dart-sdk.zip -d /usr/local && \
     mv /usr/local/dart-sdk /usr/local/dart && \
     rm /tmp/dart-sdk.zip

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
 {
   "name": "Flutter App",
   "build": {
-    "dockerfile": "Dockerfile"
+    "dockerfile": "Dockerfile",
+    "context": ".."
   },
   "postCreateCommand": "dart --version && dart pub get",
   "customizations": {


### PR DESCRIPTION
## Summary
- install Dart 3.4 SDK using an ARG
- build devcontainer with repo context and check Dart version on startup

## Testing
- `dart test --coverage` *(fails: dart command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686007bf25448324bb48069da56f56fb