### PR TITLE
Fix pubspec environment and add integration_test

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,8 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.0"
+  sdk: ">=3.4.0 <4.0.0"
 
 dependencies:
   flutter:
@@ -62,6 +61,7 @@ dev_dependencies:
   firebase_auth_mocks: ^0.13.0
   mockito: ^5.4.2
   test: ^1.31.0
+  integration_test: ^1.0.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- set Dart constraint to 3.4
- add `integration_test` dev dependency

## Testing
- `flutter pub get` *(fails: requires Dart SDK >=3.4.0)*

------
https://chatgpt.com/codex/tasks/task_e_68600a3dc5a8832497b64a3d3e8d80ac