### PR TITLE
Update devcontainer PATH and network checks

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,12 +9,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Download and install Dart SDK
 RUN wget -O /tmp/dart-sdk.zip https://storage.googleapis.com/dart-archive/channels/stable/release/${DART_VERSION}/sdk/dartsdk-linux-x64-release.zip && \
-    unzip /tmp/dart-sdk.zip -d /usr/local && \
-    mv /usr/local/dart-sdk /usr/local/dart && \
+    unzip /tmp/dart-sdk.zip -d /usr/lib && \
+    mv /usr/lib/dart-sdk /usr/lib/dart && \
     rm /tmp/dart-sdk.zip
 
 # Set PATH for Dart
-ENV PATH="/usr/local/dart/bin:${PATH}"
+ENV PATH="/usr/lib/dart/bin:${PATH}"
 
 # Verify installation
 RUN dart --version

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,11 @@
     }
   },
   "features": {},
+  "containerEnv": {
+    "GITHUB_CODESPACES_PORTS_HTTPS_PROXY_ALLOWED_HOSTS": "storage.googleapis.com,dart.dev,pub.dev,firebase-public.firebaseio.com"
+  },
   "mounts": [
     "source=${localEnv:HOME}/.pub-cache,target=/root/.pub-cache,type=bind"
-  ]
+  ],
+  "postStartCommand": "curl --fail https://storage.googleapis.com && curl --fail https://dart.dev && curl --fail https://pub.dev && curl --fail https://firebase-public.firebaseio.com"
 }


### PR DESCRIPTION
## Summary
- install Dart into `/usr/lib/dart` and persist PATH
- allow outbound connections to Dart and Firebase hosts
- fail fast if connectivity is missing on container start

## Testing
- `which dart` *(fails: command not found)*
- `dart --version` *(fails: command not found)*
- `curl --fail https://storage.googleapis.com && curl --fail https://dart.dev && curl --fail https://pub.dev && curl --fail https://firebase-public.firebaseio.com` *(fails: 403)*
- `dart test --coverage` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68600a84dddc8324b1873f9fee167f04