### PR TITLE
Install Flutter 3.32

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,9 @@
 FROM ubuntu:22.04
 
 ARG DART_VERSION=3.4.0
+ARG FLUTTER_VERSION=3.32.0
 
-# Install dependencies for Dart installation
+# Install dependencies for Dart & Flutter installation
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget unzip ca-certificates xz-utils && \
     rm -rf /var/lib/apt/lists/*
@@ -13,9 +14,14 @@ RUN wget -O /tmp/dart-sdk.zip https://storage.googleapis.com/dart-archive/channe
     mv /usr/local/dart-sdk /usr/local/dart && \
     rm /tmp/dart-sdk.zip
 
-# Set PATH for Dart
-ENV PATH="/usr/local/dart/bin:${PATH}"
+# Download and install Flutter SDK
+RUN wget -O /tmp/flutter.tar.xz https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz && \
+    tar xf /tmp/flutter.tar.xz -C /usr/local && \
+    rm /tmp/flutter.tar.xz
+
+# Set PATH for Flutter and Dart
+ENV PATH="/usr/local/flutter/bin:/usr/local/flutter/bin/cache/dart-sdk/bin:${PATH}"
 
 # Verify installation
-RUN dart --version
+RUN flutter --version && dart --version
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,10 +18,14 @@
           "storage.googleapis.com",
           "dart.dev",
           "pub.dev",
-          "firebase-public.firebaseio.com"
+          "firebase-public.firebaseio.com",
+          "raw.githubusercontent.com"
         ]
       }
     }
+  },
+  "containerEnv": {
+    "ALLOWED_DOMAINS": "raw.githubusercontent.com"
   },
   "features": {},
   "mounts": [


### PR DESCRIPTION
## Summary
- install Flutter SDK 3.32.0 alongside Dart
- set PATH for Flutter and Dart
- allow raw.githubusercontent.com domain

## Testing
- `dart test --coverage` *(fails: dart not found)*
- `flutter test integration_test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_68600cb7ef608324a1c4aeed26b1211a