### PR TITLE
Configure offline pub cache

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,11 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "postCreateCommand": "dart --version && dart pub get",
+  "postCreateCommand": "scripts/devcontainer-init.sh",
   "containerEnv": {
-    "ALLOWED_HOSTS": "storage.googleapis.com dart.dev pub.dev firebase-public.firebaseio.com"
+    "ALLOWED_HOSTS": "storage.googleapis.com dart.dev pub.dev firebase-public.firebaseio.com",
+    "GITHUB_CODESPACES_PORTS_HTTPS_PROXY_ALLOWED_HOSTS": "storage.googleapis.com,dart.dev,pub.dev,firebase-public.firebaseio.com",
+    "PUB_CACHE": "/home/vscode/.pub-cache"
   },
   "customizations": {
     "vscode": {
@@ -27,11 +29,8 @@
     }
   },
   "features": {},
-  "containerEnv": {
-    "GITHUB_CODESPACES_PORTS_HTTPS_PROXY_ALLOWED_HOSTS": "storage.googleapis.com,dart.dev,pub.dev,firebase-public.firebaseio.com"
-  },
   "mounts": [
-    "source=${localEnv:HOME}/.pub-cache,target=/root/.pub-cache,type=bind"
+    "source=${localEnv:HOME}/.pub-cache,target=/home/vscode/.pub-cache,type=bind"
   ],
   "postStartCommand": "curl --fail https://storage.googleapis.com && curl --fail https://dart.dev && curl --fail https://pub.dev && curl --fail https://firebase-public.firebaseio.com"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       PUB_HOSTED_URL: http://localhost:4873
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
+      PUB_CACHE: ~/.pub-cache
     services:
       firebase:
         image: cdrx/fake-firebase-emulator:latest
@@ -135,6 +136,7 @@ jobs:
       PUB_HOSTED_URL: http://localhost:4873
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
+      PUB_CACHE: ~/.pub-cache
     steps:
       - uses: actions/checkout@v4
       - name: Check network access
@@ -226,6 +228,7 @@ jobs:
       PUB_HOSTED_URL: https://pub.dev
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
+      PUB_CACHE: ~/.pub-cache
     steps:
       - uses: actions/checkout@v4
       - name: Check network access
@@ -293,6 +296,7 @@ jobs:
       PUB_HOSTED_URL: http://localhost:4873
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
+      PUB_CACHE: ~/.pub-cache
     steps:
       - uses: actions/checkout@v4
       - name: Check network access
@@ -391,6 +395,7 @@ jobs:
       PUB_HOSTED_URL: http://localhost:4873
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
+      PUB_CACHE: ~/.pub-cache
     steps:
       - uses: actions/checkout@v4
       - name: Check network access
@@ -488,6 +493,7 @@ jobs:
       PUB_HOSTED_URL: http://localhost:4873
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
+      PUB_CACHE: ~/.pub-cache
     steps:
       - uses: actions/checkout@v4
       - name: Check network access
@@ -585,6 +591,7 @@ jobs:
       PUB_HOSTED_URL: http://localhost:4873
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
+      PUB_CACHE: ~/.pub-cache
     steps:
       - uses: actions/checkout@v4
       - name: Check network access

--- a/scripts/devcontainer-init.sh
+++ b/scripts/devcontainer-init.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+flutter pub get
+flutter pub run build_runner build --delete-conflicting-outputs


### PR DESCRIPTION
## Summary
- mount pub cache volume in devcontainer
- add init script for codegen
- expose pub cache env in CI and devcontainer

## Testing
- `dart test --coverage=coverage` *(fails: Method not found: 'Offset')*
- `flutter test integration_test --reporter=compact` *(fails: Unable to generate build files)*

------
https://chatgpt.com/codex/tasks/task_e_68600de2e27c8324bf336ce70c76f0c6