### PR TITLE
Update devcontainer with Flutter & Dart

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,18 @@
 FROM ubuntu:22.04
 
+ARG FLUTTER_VERSION=3.32.0
 ARG DART_VERSION=3.4.0
 
-# Install dependencies for Dart installation
+# Install dependencies for Flutter & Dart
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    wget unzip ca-certificates xz-utils && \
+    wget unzip ca-certificates xz-utils git curl && \
     rm -rf /var/lib/apt/lists/*
+
+# Download and install Flutter SDK
+RUN wget -O /tmp/flutter.tar.xz https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz && \
+    mkdir -p /usr/local && \
+    tar -xJf /tmp/flutter.tar.xz -C /usr/local && \
+    rm /tmp/flutter.tar.xz
 
 # Download and install Dart SDK
 RUN wget -O /tmp/dart-sdk.zip https://storage.googleapis.com/dart-archive/channels/stable/release/${DART_VERSION}/sdk/dartsdk-linux-x64-release.zip && \
@@ -13,9 +20,11 @@ RUN wget -O /tmp/dart-sdk.zip https://storage.googleapis.com/dart-archive/channe
     mv /usr/lib/dart-sdk /usr/lib/dart && \
     rm /tmp/dart-sdk.zip
 
-# Set PATH for Dart
-ENV PATH="/usr/lib/dart/bin:${PATH}"
+# Environment variables available at build and runtime
+ENV FLUTTER_HOME=/usr/local/flutter
+ENV DART_HOME=/usr/lib/dart
+ENV PATH="$FLUTTER_HOME/bin:$FLUTTER_HOME/bin/cache/dart-sdk/bin:$DART_HOME/bin:${PATH}"
 
-# Verify installation
-RUN dart --version
+# Verify installations
+RUN flutter --version && dart --version
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "postCreateCommand": "dart --version && dart pub get",
+  "postCreateCommand": "flutter --version && dart --version && which flutter && which dart && dart pub get",
   "containerEnv": {
     "ALLOWED_HOSTS": "storage.googleapis.com dart.dev pub.dev firebase-public.firebaseio.com"
   },


### PR DESCRIPTION
## Summary
- install Flutter 3.32.0 and Dart 3.4.0 in the devcontainer Dockerfile
- expose FLUTTER_HOME, DART_HOME, and add both to PATH
- run `flutter --version` and `dart --version` at image build time
- verify Flutter and Dart in `postCreateCommand`

## Testing
- `docker build`: **failed** - `docker: command not found`
- `firebase emulators:start --only auth,firestore,storage`: **failed** - `firebase: command not found`
- `dart test --coverage`: **failed** - `dart: command not found`


------
https://chatgpt.com/codex/tasks/task_e_68600e1e68c083248535b42079e40fa4