### PR TITLE
Add Dart env setup and init checks

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,9 +13,10 @@ RUN wget -O /tmp/dart-sdk.zip https://storage.googleapis.com/dart-archive/channe
     mv /usr/lib/dart-sdk /usr/lib/dart && \
     rm /tmp/dart-sdk.zip
 
-# Set PATH for Dart
-ENV PATH="/usr/lib/dart/bin:${PATH}"
+# Set up Dart environment
+ENV DART_HOME=/usr/lib/dart
+ENV PATH="${DART_HOME}/bin:${PATH}"
 
-# Verify installation
-RUN dart --version
+# Verify installation at build time
+RUN which dart && dart --version
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,10 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "postCreateCommand": "dart --version && dart pub get",
+  "postCreateCommand": "./scripts/devcontainer-init.sh && which dart && dart --version",
   "containerEnv": {
-    "ALLOWED_HOSTS": "storage.googleapis.com dart.dev pub.dev firebase-public.firebaseio.com"
+    "ALLOWED_HOSTS": "storage.googleapis.com dart.dev pub.dev firebase-public.firebaseio.com",
+    "GITHUB_CODESPACES_PORTS_HTTPS_PROXY_ALLOWED_HOSTS": "storage.googleapis.com,dart.dev,pub.dev,firebase-public.firebaseio.com"
   },
   "customizations": {
     "vscode": {
@@ -27,11 +28,8 @@
     }
   },
   "features": {},
-  "containerEnv": {
-    "GITHUB_CODESPACES_PORTS_HTTPS_PROXY_ALLOWED_HOSTS": "storage.googleapis.com,dart.dev,pub.dev,firebase-public.firebaseio.com"
-  },
   "mounts": [
     "source=${localEnv:HOME}/.pub-cache,target=/root/.pub-cache,type=bind"
-  ],
-  "postStartCommand": "curl --fail https://storage.googleapis.com && curl --fail https://dart.dev && curl --fail https://pub.dev && curl --fail https://firebase-public.firebaseio.com"
+  ]
+
 }

--- a/scripts/devcontainer-init.sh
+++ b/scripts/devcontainer-init.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+for domain in storage.googleapis.com dart.dev pub.dev firebase-public.firebaseio.com raw.githubusercontent.com; do
+  echo "Checking $domain…"
+  curl --fail "https://$domain" -I >/dev/null
+done
+echo "All domains reachable."


### PR DESCRIPTION
## Summary
- set `DART_HOME` and ensure PATH includes dart
- verify dart exists at build time
- add `devcontainer-init.sh` connectivity script
- run connectivity script and dart checks on container creation

## Testing
- `dart test --coverage` *(fails: `dart` command not found)*
- `./scripts/devcontainer-init.sh` *(fails: 403 for storage.googleapis.com)*
- `which dart` *(fails: command not found)*
- `dart --version` *(fails: command not found)*
- `docker build` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68604a712aac83248a3626d9821fec14