### PR TITLE
Improve offline build_runner workflow

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "postCreateCommand": "scripts/devcontainer-init.sh",
+  "postCreateCommand": "curl --fail https://firebase-public.firebaseio.com && curl --fail https://storage.googleapis.com && scripts/devcontainer-init.sh",
   "containerEnv": {
     "ALLOWED_HOSTS": "storage.googleapis.com dart.dev pub.dev firebase-public.firebaseio.com",
     "GITHUB_CODESPACES_PORTS_HTTPS_PROXY_ALLOWED_HOSTS": "storage.googleapis.com,dart.dev,pub.dev,firebase-public.firebaseio.com",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
         run: |
     which dart
           dart --version
+          curl --fail https://firebase-public.firebaseio.com
+          curl --fail https://storage.googleapis.com
           for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com dart.dev; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
@@ -88,7 +90,7 @@ jobs:
         run: curl --fail https://storage.googleapis.com
       - run: flutter pub get --offline
       - run: dart pub get
-      - run: dart run build_runner build --delete-conflicting-outputs
+      - run: dart run build_runner build --delete-conflicting-outputs --offline
       - run: flutter analyze
       - run: dart analyze
       - name: Install Firebase CLI
@@ -176,6 +178,8 @@ jobs:
         run: |
     which dart
           dart --version
+          curl --fail https://firebase-public.firebaseio.com
+          curl --fail https://storage.googleapis.com
           for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com dart.dev; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
@@ -201,7 +205,7 @@ jobs:
         run: curl --fail https://storage.googleapis.com
       - run: flutter pub get --offline
       - run: dart pub get
-      - run: dart run build_runner build --delete-conflicting-outputs
+      - run: dart run build_runner build --delete-conflicting-outputs --offline
       - run: flutter analyze
       - run: dart analyze
       - run: flutter pub downgrade || true
@@ -268,6 +272,8 @@ jobs:
         run: |
     which dart
           dart --version
+          curl --fail https://firebase-public.firebaseio.com
+          curl --fail https://storage.googleapis.com
           for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com dart.dev; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
@@ -336,6 +342,8 @@ jobs:
         run: |
     which dart
           dart --version
+          curl --fail https://firebase-public.firebaseio.com
+          curl --fail https://storage.googleapis.com
           for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com dart.dev; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
@@ -361,7 +369,7 @@ jobs:
         run: curl --fail https://storage.googleapis.com
       - run: flutter pub get --offline
       - run: dart pub get
-      - run: dart run build_runner build --delete-conflicting-outputs
+      - run: dart run build_runner build --delete-conflicting-outputs --offline
       - run: flutter analyze
       - run: dart analyze
       - run: flutter pub downgrade || true
@@ -435,6 +443,8 @@ jobs:
         run: |
     which dart
           dart --version
+          curl --fail https://firebase-public.firebaseio.com
+          curl --fail https://storage.googleapis.com
           for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com dart.dev; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
@@ -460,7 +470,7 @@ jobs:
         run: curl --fail https://storage.googleapis.com
       - run: flutter pub get --offline
       - run: dart pub get
-      - run: dart run build_runner build --delete-conflicting-outputs
+      - run: dart run build_runner build --delete-conflicting-outputs --offline
       - run: flutter analyze
       - run: dart analyze
       - run: flutter pub downgrade || true
@@ -533,6 +543,8 @@ jobs:
         run: |
     which dart
           dart --version
+          curl --fail https://firebase-public.firebaseio.com
+          curl --fail https://storage.googleapis.com
           for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com dart.dev; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
@@ -558,7 +570,7 @@ jobs:
         run: curl --fail https://storage.googleapis.com
       - run: flutter pub get --offline
       - run: dart pub get
-      - run: dart run build_runner build --delete-conflicting-outputs
+      - run: dart run build_runner build --delete-conflicting-outputs --offline
       - run: flutter analyze
       - run: dart analyze
       - run: flutter pub downgrade || true
@@ -631,6 +643,8 @@ jobs:
         run: |
     which dart
           dart --version
+          curl --fail https://firebase-public.firebaseio.com
+          curl --fail https://storage.googleapis.com
           for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com dart.dev; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
@@ -652,7 +666,7 @@ jobs:
         run: curl --fail https://storage.googleapis.com
       - run: flutter pub get --offline
       - run: dart pub get
-      - run: dart run build_runner build --delete-conflicting-outputs
+      - run: dart run build_runner build --delete-conflicting-outputs --offline
       - run: flutter analyze
       - run: dart analyze
       - run: flutter pub downgrade || true

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -56,6 +56,8 @@ jobs:
         run: |
           which dart
           dart --version
+          curl --fail https://firebase-public.firebaseio.com
+          curl --fail https://storage.googleapis.com
           for host in storage.googleapis.com pub.dev raw.githubusercontent.com dart.dev firebase.google.com; do
             curl --head --fail https://$host || { echo "❌ Cannot reach $host"; exit 1; }
           done
@@ -70,12 +72,12 @@ jobs:
       - name: Get dependencies with retry
         run: |
           for i in 1 2 3; do
-            flutter pub get && break || sleep 5
+            flutter pub get --offline && break || sleep 5
           done
       - run: dart pub get
       - name: Verify firebase_app_check resolution
         run: grep firebase_app_check pubspec.lock
-      - run: dart run build_runner build --delete-conflicting-outputs
+      - run: dart run build_runner build --delete-conflicting-outputs --offline
       - run: flutter analyze
       - run: dart analyze
       - name: Run tests with coverage

--- a/.github/workflows/flutter_web.yml
+++ b/.github/workflows/flutter_web.yml
@@ -52,6 +52,8 @@ jobs:
       run: |
     which dart
         dart --version
+        curl --fail https://firebase-public.firebaseio.com
+        curl --fail https://storage.googleapis.com
         for host in storage.googleapis.com pub.dev raw.githubusercontent.com dart.dev firebase.google.com; do
           curl --head --fail https://$host || { echo "❌ Cannot reach $host"; exit 1; }
         done
@@ -63,9 +65,9 @@ jobs:
         curl --fail https://dart.dev
         curl --fail https://pub.dev
         curl --fail https://firebase-public.firebaseio.com
-    - run: flutter pub get
+    - run: flutter pub get --offline
     - run: dart pub get
-    - run: dart run build_runner build --delete-conflicting-outputs
+    - run: dart run build_runner build --delete-conflicting-outputs --offline
     - name: Configure offline pub cache
       run: echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
     - name: Check storage connectivity

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -46,6 +46,8 @@ jobs:
         run: |
     which dart
           dart --version
+          curl --fail https://firebase-public.firebaseio.com
+          curl --fail https://storage.googleapis.com
           for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com dart.dev; do
             curl --head --fail https://$host || { echo "❌ Cannot reach $host"; exit 1; }
           done
@@ -64,9 +66,9 @@ jobs:
           curl --fail https://dart.dev
           curl --fail https://pub.dev
           curl --fail https://firebase-public.firebaseio.com
-      - run: flutter pub get
+      - run: flutter pub get --offline
       - run: dart pub get
-      - run: dart run build_runner build --delete-conflicting-outputs
+      - run: dart run build_runner build --delete-conflicting-outputs --offline
       - name: Check storage connectivity
         run: curl --fail https://storage.googleapis.com
       - name: Configure offline pub cache

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -37,6 +37,8 @@ jobs:
         run: |
           which dart
           dart --version
+          curl --fail https://firebase-public.firebaseio.com
+          curl --fail https://storage.googleapis.com
           for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com dart.dev; do
             curl --head --fail https://$host || { echo "u274c Cannot reach $host" >&2; exit 1; }
           done
@@ -48,9 +50,9 @@ jobs:
           curl --fail https://dart.dev
           curl --fail https://pub.dev
           curl --fail https://firebase-public.firebaseio.com
-      - run: flutter pub get
+      - run: flutter pub get --offline
       - run: dart pub get
-      - run: dart run build_runner build --delete-conflicting-outputs
+      - run: dart run build_runner build --delete-conflicting-outputs --offline
       - run: dart test --coverage
       - name: Calculate coverage
         id: cov

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  build_runner: ^2.4.7
+  build_runner: ^2.3.0
   freezed: ^2.5.2
   json_serializable: ^6.7.1
   fake_cloud_firestore: ^2.4.0

--- a/scripts/devcontainer-init.sh
+++ b/scripts/devcontainer-init.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
-flutter pub get
-flutter pub run build_runner build --delete-conflicting-outputs
+flutter pub get --offline
+flutter pub run build_runner build --delete-conflicting-outputs --offline


### PR DESCRIPTION
## Summary
- run `flutter pub get` and `build_runner` offline in devcontainer
- verify Firebase and storage URLs during container creation
- update build_runner to version 2.3.0
- check Firebase and storage hosts during CI pre-flight
- run build_runner offline in CI workflows

## Testing
- `./scripts/devcontainer-init.sh` *(fails: command not found)*
- `dart test --coverage=coverage` *(fails: command not found)*
- `flutter test integration_test --reporter=compact` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604ac53b1c832484ac9db720b3ed1b