### PR TITLE
Fix pubspec dev dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,15 +52,6 @@ dependencies:
   syncfusion_flutter_charts: 28.2.6
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
-  build_runner: ^2.3.0
-  freezed: ^2.5.2
-  json_serializable: ^6.7.1
-  fake_cloud_firestore: ^2.4.0
-  firebase_auth_mocks: ^0.13.0
-  mockito: ^5.4.2
-  test: ^1.24.9
   integration_test: ^1.0.0
 
 flutter:


### PR DESCRIPTION
## Summary
- remove unused dev dependency entries in `pubspec.yaml`
- keep only `integration_test` under `dev_dependencies`

## Testing
- `flutter pub get` *(fails: Failed to retrieve the Dart SDK)*
- `dart test --coverage` *(fails: Failed to retrieve the Dart SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68605bb1de6883249a338a67e4d94c91