### PR TITLE
Fix devcontainer commands and ensure local Dockerfile

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,10 @@
   "settings": {
     "terminal.integrated.shell.linux": "/bin/bash"
   },
-  "postCreateCommand": "bash -c \"which flutter && flutter --version && which dart && dart --version\"",
+  "postCreateCommand": [
+    "which flutter && flutter --version",
+    "which dart    && dart --version"
+  ],
   "mounts": [
     // Mount host pub cache for offline packages
     "source=${localEnv:HOME}/.pub-cache,target=/home/vscode/.pub-cache,type=bind,consistency=cached"


### PR DESCRIPTION
## Summary
- update `.devcontainer/devcontainer.json` so `postCreateCommand` runs `flutter --version` and `dart --version`
- keep PUB_CACHE mount and environment settings

## Testing
- `dart test --coverage` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68605bbc3e6083249df9ed8893568141