### PR TITLE
Start Firebase emulators in CI

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -80,6 +80,15 @@ jobs:
       - run: dart run build_runner build --delete-conflicting-outputs --offline
       - run: flutter analyze
       - run: dart analyze
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+      - name: Start Firebase emulators
+        run: |
+          echo "FIREBASE_AUTH_EMULATOR_HOST=localhost:9099" >> $GITHUB_ENV
+          echo "FIRESTORE_EMULATOR_HOST=localhost:8080" >> $GITHUB_ENV
+          echo "FIREBASE_STORAGE_EMULATOR_HOST=localhost:9199" >> $GITHUB_ENV
+          firebase emulators:start --only auth,firestore,storage --project app-oint-core &
+          sleep 5
       - name: Run tests with coverage
         run: flutter test --coverage
       - run: flutter test integration_test


### PR DESCRIPTION
## Summary
- start firebase emulators in `flutter.yml`
- set emulator host environment variables so tests can connect locally

## Testing
- `firebase --version`
- `dart test --coverage` *(fails: SDK version too low)*

------
https://chatgpt.com/codex/tasks/task_e_68605bd8cb908324829b3a00203f63c3