### PR TITLE
Update devcontainer mounts

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,11 +11,13 @@
   },
   "postCreateCommand": [
     "which flutter && flutter --version",
-    "which dart    && dart --version"
+    "which dart    && dart --version",
+    "bash -c \"ls /workspace/sdk_archives && which flutter && which dart\""
   ],
   "mounts": [
     // Mount host pub cache for offline packages
-    "source=${localEnv:HOME}/.pub-cache,target=/home/vscode/.pub-cache,type=bind,consistency=cached"
+    "source=${localEnv:HOME}/.pub-cache,target=/home/vscode/.pub-cache,type=bind,consistency=cached",
+    "source=${localWorkspaceFolder}/sdk_archives,target=/workspace/sdk_archives,type=bind,consistency=cached"
   ],
   "containerEnv": {
     "PUB_CACHE": "/home/vscode/.pub-cache"


### PR DESCRIPTION
## Summary
- mount sdk archives from the host so they're visible inside the dev container
- ensure `postCreateCommand` lists the sdk archives and checks flutter/dart executables

## Testing
- `dart test --coverage` *(fails: SDK constraint >=3.4.0 <4.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68605fd2dfe48324a546528d6de73971