### PR TITLE
Add referral code generation feature

### DIFF
--- a/lib/features/referral/referral_screen.dart
+++ b/lib/features/referral/referral_screen.dart
@@ -15,27 +15,36 @@ class ReferralScreen extends ConsumerWidget {
       appBar: AppBar(title: const Text('Referral Code')),
       body: Center(
         child: codeAsync.when(
-          data: (code) => Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const Text('Your referral code:'),
-              const SizedBox(height: 12),
-              SelectableText(
-                code,
-                style: Theme.of(context).textTheme.headlineMedium,
+          data: (code) => Card(
+            margin: const EdgeInsets.all(16),
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Text(
+                    'Your Invite Code',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 12),
+                  SelectableText(
+                    code,
+                    style: Theme.of(context).textTheme.headlineMedium,
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton.icon(
+                    icon: const Icon(Icons.copy),
+                    label: const Text('Copy'),
+                    onPressed: () {
+                      Clipboard.setData(ClipboardData(text: code));
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Copied to clipboard')),
+                      );
+                    },
+                  ),
+                ],
               ),
-              const SizedBox(height: 16),
-              ElevatedButton.icon(
-                icon: const Icon(Icons.copy),
-                label: const Text('Copy'),
-                onPressed: () {
-                  Clipboard.setData(ClipboardData(text: code));
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Copied to clipboard')),
-                  );
-                },
-              ),
-            ],
+            ),
           ),
           loading: () => const CircularProgressIndicator(),
           error: (e, _) => const Text('Error loading referral code'),

--- a/lib/models/referral_code.dart
+++ b/lib/models/referral_code.dart
@@ -1,0 +1,29 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class ReferralCode {
+  final String userId;
+  final String code;
+  final DateTime createdAt;
+
+  ReferralCode({
+    required this.userId,
+    required this.code,
+    required this.createdAt,
+  });
+
+  factory ReferralCode.fromMap(Map<String, dynamic> map) {
+    return ReferralCode(
+      userId: map['userId'] as String,
+      code: map['code'] as String,
+      createdAt: (map['createdAt'] as Timestamp).toDate(),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'userId': userId,
+      'code': code,
+      'createdAt': Timestamp.fromDate(createdAt),
+    };
+  }
+}

--- a/lib/providers/referral_provider.dart
+++ b/lib/providers/referral_provider.dart
@@ -1,10 +1,15 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../services/referral_service.dart';
+import 'auth_provider.dart';
 
 final referralServiceProvider =
     Provider<ReferralService>((ref) => ReferralService());
 
-final referralCodeProvider = FutureProvider<String>((ref) {
-  return ref.read(referralServiceProvider).generateReferralCode();
+final referralCodeProvider = FutureProvider<String>((ref) async {
+  final user = ref.read(authProvider).currentUser;
+  if (user == null) {
+    throw Exception('User not logged in');
+  }
+  return ref.read(referralServiceProvider).generateReferralCode(user.uid);
 });

--- a/lib/services/referral_service.dart
+++ b/lib/services/referral_service.dart
@@ -11,43 +11,43 @@ class ReferralService {
       : _firestore = firestore ?? FirebaseFirestore.instance,
         _auth = auth ?? FirebaseAuth.instance;
 
-  Future<String> generateReferralCode() async {
-    final user = _auth.currentUser;
-    if (user == null) {
-      throw Exception('User not logged in');
-    }
-
-    // Return existing code if already generated
-    final existing = await _firestore
-        .collection('referral_codes')
-        .where('userId', isEqualTo: user.uid)
-        .limit(1)
-        .get();
-    if (existing.docs.isNotEmpty) {
-      return existing.docs.first.data()['code'] as String;
+  Future<String> generateReferralCode(String userId) async {
+    final docRef = _firestore.collection('referrals').doc(userId);
+    final existing = await docRef.get();
+    final data = existing.data();
+    if (data != null && data['code'] is String) {
+      return data['code'] as String;
     }
 
     String code;
     bool exists = true;
     final random = Random();
-    const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
     do {
       code =
-          List.generate(6, (_) => chars[random.nextInt(chars.length)]).join();
+          List.generate(8, (_) => chars[random.nextInt(chars.length)]).join();
       final query = await _firestore
-          .collection('referral_codes')
+          .collection('referrals')
           .where('code', isEqualTo: code)
           .limit(1)
           .get();
       exists = query.docs.isNotEmpty;
     } while (exists);
 
-    await _firestore.collection('referral_codes').add({
-      'userId': user.uid,
+    await docRef.set({
+      'userId': userId,
       'code': code,
       'createdAt': FieldValue.serverTimestamp(),
     });
 
     return code;
+  }
+
+  Future<String> generateReferralCodeForCurrentUser() async {
+    final user = _auth.currentUser;
+    if (user == null) {
+      throw Exception('User not logged in');
+    }
+    return generateReferralCode(user.uid);
   }
 }

--- a/test/services/referral_service_test.dart
+++ b/test/services/referral_service_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/services/referral_service.dart';
+import '../fake_firebase_setup.dart';
+import '../fake_firebase_firestore.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  group('ReferralService', () {
+    late ReferralService service;
+    late FakeFirebaseFirestore firestore;
+
+    setUp(() {
+      firestore = FakeFirebaseFirestore();
+      service = ReferralService(firestore: firestore);
+    });
+
+    test('generates and persists 8 character code', () async {
+      final code = await service.generateReferralCode('user1');
+      expect(code.length, 8);
+      final stored = await firestore.collection('referrals').doc('user1').get();
+      expect(stored.exists, true);
+      expect(stored.data()!['code'], code);
+    });
+
+    test('returns same code on subsequent calls', () async {
+      final first = await service.generateReferralCode('user1');
+      final second = await service.generateReferralCode('user1');
+      expect(first, second);
+    });
+
+    test('codes for different users are unique', () async {
+      final first = await service.generateReferralCode('user1');
+      final second = await service.generateReferralCode('user2');
+      expect(first == second, false);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- implement `generateReferralCode(String)` with Firestore persistence
- expose current user code via provider and show in a card
- add `ReferralCode` model
- add unit tests for referral service

## Testing
- `dart test --coverage` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_686061652d0c8324b0cef0d88eb8f872