### PR TITLE
Update dev container instructions in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,12 @@ dart run                  # CLI
 flutter run -d chrome      # Web
 ```
 
+## Dev Container
+
+The dev container (`.devcontainer/Dockerfile`) installs Flutter 3.32.0 and Dart
+3.4.0 from pre-downloaded archives. Before building, place the required SDK
+archives under `.devcontainer/sdk_archives` so no network download is needed.
+
 ## Testing
 
 ```bash


### PR DESCRIPTION
## Summary
- document local SDK archives in `AGENTS.md`

## Testing
- `dart test --coverage` *(fails: dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860620d0d248324b6e85935a8d40748