### PR TITLE
Improve Docker caching

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -33,6 +33,14 @@ RUN ln -s $FLUTTER_HOME/bin/flutter /usr/local/bin/flutter \
 # Verify installations at build time
 RUN which flutter && flutter --version && which dart && dart --version
 
+# Stage 1 – Cache Dependencies
+WORKDIR /workspace
+COPY pubspec.yaml pubspec.lock ./
+RUN flutter pub get && dart pub get
+
+# Copy app sources after caching dependencies
+COPY . .
+
 # Set up working directory
 WORKDIR /workspace
 

--- a/scripts/devcontainer-init.sh
+++ b/scripts/devcontainer-init.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 set -e
-flutter pub get --offline
 flutter pub run build_runner build --delete-conflicting-outputs --offline


### PR DESCRIPTION
## Summary
- cache dependencies in devcontainer Dockerfile
- copy full source after dependencies
- stop running `flutter pub get` in the init script

## Testing
- `dart pub get --offline` *(fails: domain not in allowlist)*
- `dart test --coverage` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_6860640d89588324b71c50ff680d3811