### PR TITLE
Persist Flutter/Dart paths in dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,6 +29,9 @@ ENV DART_HOME=/usr/lib/dart
 ENV PATH="$FLUTTER_HOME/bin:$FLUTTER_HOME/bin/cache/dart-sdk/bin:$DART_HOME/bin:${PATH}"
 RUN ln -s $FLUTTER_HOME/bin/flutter /usr/local/bin/flutter \
     && ln -s $DART_HOME/bin/dart      /usr/local/bin/dart
+# Persist SDK paths for all shells
+RUN printf 'PATH="/usr/local/flutter/bin:/usr/local/flutter/bin/cache/dart-sdk/bin:/usr/local/bin:${PATH}"\n' \
+     >> /etc/environment
 
 # Verify installations at build time
 RUN which flutter && flutter --version && which dart && dart --version

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,5 +22,8 @@
   "containerEnv": {
     "PATH": "/usr/local/flutter/bin:/usr/local/flutter/bin/cache/dart-sdk/bin:/usr/local/bin:${containerEnv:PATH}",
     "PUB_CACHE": "/home/vscode/.pub-cache"
+  },
+  "remoteEnv": {
+    "PATH": "/usr/local/flutter/bin:/usr/local/flutter/bin/cache/dart-sdk/bin:/usr/local/bin:${containerEnv:PATH}"
   }
 }


### PR DESCRIPTION
## Summary
- ensure Flutter/Dart paths are available to all shells
- expose PATH via devcontainer remoteEnv

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `PATH=/workspace/flutter_sdk/bin:$PATH npx firebase emulators:start --only auth,firestore,storage` *(fails: could not determine executable to run)*
- `PATH=/workspace/flutter_sdk/bin:$PATH dart test --coverage` *(fails: blocked on storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_68606481c59c832490ec2ba3c73f9f49