### PR TITLE
Add dart visibility to container workflows

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,6 @@
 # Use an official lightweight base image
 FROM ubuntu:22.04
 
-# Copy pre-downloaded SDK archives into the container
-COPY sdk_archives /tmp/sdk_archives
-
 # Install dependencies
 RUN apt-get update && apt-get install -y \
     curl \
@@ -13,19 +10,23 @@ RUN apt-get update && apt-get install -y \
     zip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Flutter 3.32.0 and Dart 3.4.0 from local archives
-RUN tar xf /tmp/sdk_archives/flutter_linux_3.32.0-stable.tar.xz -C /usr/local \
-    && unzip /tmp/sdk_archives/dartsdk-linux-x64-release.zip -d /usr/lib/dart \
-    && rm -rf /tmp/sdk_archives
+# Install Flutter 3.32.0 and Dart 3.4.0
+RUN curl -L https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.32.0-stable.tar.xz -o flutter.tar.xz \
+    && tar xf flutter.tar.xz -C /usr/local \
+    && rm flutter.tar.xz \
+    && curl -L https://storage.googleapis.com/dart-archive/channels/stable/release/3.4.0/sdk/dartsdk-linux-x64-release.zip -o dart.zip \
+    && unzip dart.zip -d /usr/lib/dart \
+    && rm dart.zip
 
 # Symlink flutter and dart into /usr/local/bin for easy access
 RUN ln -s /usr/local/flutter/bin/flutter /usr/local/bin/flutter \
- && ln -s /usr/local/flutter/bin/cache/dart-sdk/bin/dart /usr/local/bin/dart
+    && ln -s /usr/lib/dart/dart-sdk/bin/dart /usr/local/bin/dart \
+    && rm -f /etc/profile.d/sdk-path.sh
 
 # Expose environment variables for both build and runtime
 ENV FLUTTER_HOME=/usr/local/flutter
-ENV DART_HOME=/usr/lib/dart
-ENV PATH="$FLUTTER_HOME/bin:$FLUTTER_HOME/bin/cache/dart-sdk/bin:$DART_HOME/bin:${PATH}"
+ENV DART_HOME=/usr/lib/dart/dart-sdk
+ENV PATH="$FLUTTER_HOME/bin:$DART_HOME/bin:${PATH}"
 
 # Verify installations at build time
 RUN which flutter && flutter --version && which dart && dart --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/your-org/app-oint-dev:latest
+      options: --pull
     env:
       PUB_HOSTED_URL: http://localhost:4873
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
@@ -62,6 +63,11 @@ jobs:
           for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com dart.dev; do
             curl --head --fail https://$host || { echo "✗ Cannot reach $host"; exit 1; }
           done
+      - name: Debug SDK in Container
+        run: |
+          echo "CI PATH: $PATH"
+          which flutter || echo "flutter not found"
+          which dart    || echo "dart not found"
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
@@ -130,6 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/your-org/app-oint-dev:latest
+      options: --pull
     env:
       PUB_HOSTED_URL: http://localhost:4873
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
@@ -224,6 +231,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/your-org/app-oint-dev:latest
+      options: --pull
     if: github.ref == 'refs/heads/main'
     env:
       PUB_HOSTED_URL: https://pub.dev
@@ -289,6 +297,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/your-org/app-oint-dev:latest
+      options: --pull
     if: github.ref == 'refs/heads/main'
     env:
       PUB_HOSTED_URL: http://localhost:4873
@@ -391,6 +400,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/your-org/app-oint-dev:latest
+      options: --pull
     if: github.ref == 'refs/heads/main'
     env:
       PUB_HOSTED_URL: http://localhost:4873
@@ -591,6 +601,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/your-org/app-oint-dev:latest
+      options: --pull
     if: always()
     env:
       PUB_HOSTED_URL: http://localhost:4873

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/your-org/app-oint-dev:latest
+      options: --pull
     env:
       PUB_HOSTED_URL: https://pub.dev
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
@@ -52,6 +53,11 @@ jobs:
           for host in storage.googleapis.com pub.dev raw.githubusercontent.com dart.dev firebase.google.com; do
             curl --head --fail https://$host || { echo "❌ Cannot reach $host"; exit 1; }
           done
+      - name: Debug SDK in Container
+        run: |
+          echo "CI PATH: $PATH"
+          which flutter || echo "flutter not found"
+          which dart || echo "dart not found"
       - name: Check storage connectivity
         run: curl --fail https://storage.googleapis.com
       - name: Check network access


### PR DESCRIPTION
## Summary
- install Flutter 3.32.0 and Dart 3.4.0 directly in the dev container
- expose dart and flutter binaries in `$PATH`
- pull the latest container for CI jobs and debug SDK paths

## Testing
- `dart test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860636262748324a55af418e9ec0732