### PR TITLE
Add profile script for Flutter/Dart PATH

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,6 +30,11 @@ ENV PATH="$FLUTTER_HOME/bin:$FLUTTER_HOME/bin/cache/dart-sdk/bin:$DART_HOME/bin:
 # Verify installations at build time
 RUN which flutter && flutter --version && which dart && dart --version
 
+# Ensure Flutter & Dart are always on PATH
+RUN printf 'export PATH="/usr/local/flutter/bin:/usr/local/flutter/bin/cache/dart-sdk/bin:/usr/local/bin:$PATH"\n' \
+    > /etc/profile.d/sdk-path.sh \
+ && chmod +x /etc/profile.d/sdk-path.sh
+
 # Set up working directory
 WORKDIR /workspace
 


### PR DESCRIPTION
## Summary
- update `.devcontainer/Dockerfile` to create `/etc/profile.d/sdk-path.sh`

## Testing
- `dart test --coverage` *(fails: The current Dart SDK version is 3.3.0. Because appoint requires SDK version >=3.4.0 <4.0.0, version solving failed.)*

------
https://chatgpt.com/codex/tasks/task_e_68606300af40832491add0bcdf971065