### PR TITLE
Cache pub cache in dev Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,10 +36,15 @@ RUN which flutter && flutter --version && which dart && dart --version
 # Stage 1 – Cache Dependencies
 WORKDIR /workspace
 COPY pubspec.yaml pubspec.lock ./
-RUN flutter pub get && dart pub get
+RUN flutter pub get && dart pub get \
+    && tar czf /tmp/pub_cache.tar.gz ~/.pub-cache
 
 # Copy app sources after caching dependencies
 COPY . .
+
+# Restore cached dependencies for subsequent steps
+RUN mkdir -p ~/.pub-cache \
+    && tar xzf /tmp/pub_cache.tar.gz -C ~
 
 # Set up working directory
 WORKDIR /workspace

--- a/analyze_in_codespace.sh
+++ b/analyze_in_codespace.sh
@@ -2,9 +2,7 @@
 echo "🧼 Cleaning..."
 flutter clean
 
-echo "📦 Getting packages..."
-dart pub get
-flutter pub get
+echo "📦 Packages preloaded via Docker cache"
 
 echo "🛠️ Running build_runner..."
 flutter pub run build_runner build --delete-conflicting-outputs

--- a/sync_and_rebuild.sh
+++ b/sync_and_rebuild.sh
@@ -4,7 +4,6 @@ git pull origin main
 
 echo "🧹 Cleaning project..."
 flutter clean
-dart pub get
 
 echo "🔁 Running build_runner..."
 flutter pub run build_runner build --delete-conflicting-outputs


### PR DESCRIPTION
## Summary
- cache flutter/dart packages in devcontainer build
- restore cached pub deps after copying the source
- remove `pub get` calls from dev helper scripts

## Testing
- `dart pub get --offline` *(fails: requires Dart 3.4.0)*
- `dart test --coverage` *(fails: requires Dart 3.4.0)*

------
https://chatgpt.com/codex/tasks/task_e_686065945ad88324a1e5767255070d8c