### PR TITLE
Update Dockerfile to fetch Dart 3.4.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # Use an official lightweight base image
 FROM ubuntu:22.04
 
-# Copy pre-downloaded SDK archives into the container
+# Copy pre-downloaded Flutter archive into the container
 COPY sdk_archives /tmp/sdk_archives
 
 # Install dependencies
@@ -13,41 +13,42 @@ RUN apt-get update && apt-get install -y \
     zip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Flutter 3.32.0 and Dart 3.4.0 from local archives
+# Install Flutter 3.32.0 from the local archive
 RUN tar xf /tmp/sdk_archives/flutter_linux_3.32.0-stable.tar.xz -C /usr/local \
-    && unzip -q /tmp/sdk_archives/dartsdk-linux-x64-release.zip -d /usr/lib \
-    && mv /usr/lib/dart-sdk /usr/lib/dart \
     && rm -rf /tmp/sdk_archives
+
+# Install Dart 3.4.0 directly
+RUN curl -fsSL https://storage.googleapis.com/dart-archive/channels/stable/release/3.4.0/sdk/dartsdk-linux-x64-release.zip \
+        -o dartsdk.zip \
+    && unzip -q dartsdk.zip -d /usr/lib \
+    && mv /usr/lib/dart-sdk /usr/lib/dart \
+    && rm dartsdk.zip
 
 # Symlink flutter and dart into /usr/local/bin for easy access
 RUN ln -s /usr/local/flutter/bin/flutter /usr/local/bin/flutter \
- && ln -s /usr/local/flutter/bin/cache/dart-sdk/bin/dart /usr/local/bin/dart
+ && ln -s /usr/lib/dart/bin/dart /usr/local/bin/dart
 
 # Expose environment variables for both build and runtime
 ENV FLUTTER_HOME=/usr/local/flutter
 ENV DART_HOME=/usr/lib/dart
-ENV PATH="$FLUTTER_HOME/bin:$FLUTTER_HOME/bin/cache/dart-sdk/bin:$DART_HOME/bin:${PATH}"
+ENV PATH="$FLUTTER_HOME/bin:$DART_HOME/bin:${PATH}"
 RUN ln -s $FLUTTER_HOME/bin/flutter /usr/local/bin/flutter \
     && ln -s $DART_HOME/bin/dart      /usr/local/bin/dart
 # Persist SDK paths for all shells
-RUN printf 'PATH="/usr/local/flutter/bin:/usr/local/flutter/bin/cache/dart-sdk/bin:/usr/local/bin:${PATH}"\n' \
+RUN printf 'PATH="/usr/local/flutter/bin:$DART_HOME/bin:/usr/local/bin:${PATH}"\n' \
      >> /etc/environment
 
 # Verify installations at build time
 RUN which flutter && flutter --version && which dart && dart --version
+RUN dart --version
 
 # Stage 1 – Cache Dependencies
 WORKDIR /workspace
 COPY pubspec.yaml pubspec.lock ./
-RUN flutter pub get && dart pub get \
-    && tar czf /tmp/pub_cache.tar.gz ~/.pub-cache
+RUN flutter pub get && dart pub get
 
 # Copy app sources after caching dependencies
 COPY . .
-
-# Restore cached dependencies for subsequent steps
-RUN mkdir -p ~/.pub-cache \
-    && tar xzf /tmp/pub_cache.tar.gz -C ~
 
 # Set up working directory
 WORKDIR /workspace


### PR DESCRIPTION
## Summary
- use curl to install Dart 3.4.0 from the archive
- adjust PATH and symlinks so the Dart CLI is accessible
- vendor pub dependencies during build

## Testing
- `dart test --coverage` *(fails: Dart 3.3.0 in runner)*

------
https://chatgpt.com/codex/tasks/task_e_68606897cb1c83249439d1933addf69c