### PR TITLE
Batch E1 – Core Authentication & Routing Recovery

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -27,6 +27,8 @@ import '../features/admin/admin_demo_panel_screen.dart';
 import '../features/calendar/google_integration_screen.dart';
 import '../features/ambassador_dashboard_screen.dart';
 import '../features/ambassador_onboarding_screen.dart';
+import '../features/studio_profile/studio_profile_screen.dart';
+import '../features/studio_business/entry/business_entry_screen.dart';
 import '../models/invite.dart';
 import 'package:appoint/features/studio_business/screens/business_dashboard_screen.dart';
 import 'package:appoint/features/studio_business/screens/business_profile_screen.dart';
@@ -37,6 +39,7 @@ import '../features/personal_app/ui/notifications_screen.dart';
 import '../features/common/ui/error_screen.dart';
 import '../features/referral/referral_screen.dart';
 import '../features/rewards/rewards_screen.dart';
+import '../features/common/ui/unsupported_screen.dart';
 
 class AppRouter {
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
@@ -116,6 +119,11 @@ class AppRouter {
           builder: (_) => const FamilyDashboardScreen(),
           settings: settings,
         );
+      case '/child/dashboard':
+        return MaterialPageRoute(
+          builder: (_) => const FamilyDashboardScreen(),
+          settings: settings,
+        );
       case '/family/invite-child':
         return MaterialPageRoute(
           builder: (_) => const InviteChildScreen(),
@@ -190,9 +198,20 @@ class AppRouter {
           builder: (_) => const BusinessDashboardScreen(),
           settings: settings,
         );
+      case '/business':
+        return MaterialPageRoute(
+          builder: (_) => const BusinessEntryScreen(),
+          settings: settings,
+        );
       case '/business/profile':
         return MaterialPageRoute(
           builder: (_) => const BusinessProfileScreen(),
+          settings: settings,
+        );
+      case '/studio/profile':
+        final studioId = settings.arguments as String? ?? '';
+        return MaterialPageRoute(
+          builder: (_) => StudioProfileScreen(studioId: studioId),
           settings: settings,
         );
       case '/invite/list':
@@ -233,6 +252,11 @@ class AppRouter {
             message: args['message'] as String? ?? 'An error occurred',
             onTryAgain: args['onTryAgain'] as VoidCallback? ?? () {},
           ),
+          settings: settings,
+        );
+      case '/unsupported':
+        return MaterialPageRoute(
+          builder: (_) => const UnsupportedScreen(),
           settings: settings,
         );
       default:

--- a/lib/features/auth/auth_wrapper.dart
+++ b/lib/features/auth/auth_wrapper.dart
@@ -2,9 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../providers/auth_provider.dart';
-import '../../models/user_type.dart';
 import '../studio_business/entry/business_entry_screen.dart';
 import '../studio_profile/studio_profile_screen.dart';
+import '../admin/ui/admin_dashboard_screen.dart';
+import '../family/screens/family_dashboard_screen.dart';
 import 'home_screen.dart';
 import 'login_screen.dart';
 
@@ -21,23 +22,18 @@ class AuthWrapper extends ConsumerWidget {
           return const LoginScreen();
         }
 
-        // TODO: Replace this with actual user type detection from Firebase
-        // For now, we'll use a simple approach based on user claims or profile
-        final userType = _getUserType(user);
-
-        switch (userType) {
-          case UserType.business:
-            return const BusinessEntryScreen();
-          case UserType.studio:
-            // TODO: Replace 'studioId' with actual studioId from user profile
-            return const StudioProfileScreen(studioId: 'studioId');
-          case UserType.admin:
-            // TODO: Add admin routing when admin screens are ready
-            return const HomeScreen();
-          case UserType.child:
-            // TODO: Add child routing when child screens are ready
-            return const HomeScreen();
-          case UserType.personal:
+        switch (user.role) {
+          case 'business':
+          case 'studio':
+            return user.studioId != null
+                ? StudioProfileScreen(studioId: user.studioId!)
+                : const BusinessEntryScreen();
+          case 'admin':
+            return const AdminDashboardScreen();
+          case 'child':
+            return const FamilyDashboardScreen();
+          case 'personal':
+          default:
             return const HomeScreen();
         }
       },
@@ -48,13 +44,5 @@ class AuthWrapper extends ConsumerWidget {
         body: Center(child: Text('Error')),
       ),
     );
-  }
-
-  /// Temporary method to determine user type
-  /// TODO: Replace with actual Firebase user claims or profile data
-  UserType _getUserType(dynamic user) {
-    // For now, return personal as default
-    // This should be replaced with actual user type detection logic
-    return UserType.personal;
   }
 }

--- a/lib/features/common/ui/unsupported_screen.dart
+++ b/lib/features/common/ui/unsupported_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+/// Screen shown when the user has an unsupported role or route.
+class UnsupportedScreen extends StatelessWidget {
+  const UnsupportedScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Text(
+          'Unsupported account type',
+          style: Theme.of(context).textTheme.headlineSmall,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/models/app_user.dart
+++ b/lib/models/app_user.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/foundation.dart';
+
+/// Simplified user model built from Firebase custom claims.
+class AppUser {
+  final String uid;
+  final String? email;
+  final String role;
+  final String? studioId;
+  final String? businessProfileId;
+
+  const AppUser({
+    required this.uid,
+    this.email,
+    required this.role,
+    this.studioId,
+    this.businessProfileId,
+  });
+}
+

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -1,11 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../core/auth_service.dart';
+import '../services/auth_service.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import '../models/app_user.dart';
 
 final authServiceProvider = Provider<AuthService>((ref) => AuthService());
 
-final authStateProvider = FutureProvider<User?>(
-  (ref) => ref.read(authServiceProvider).currentUser(),
+final authStateProvider = StreamProvider<AppUser?>(
+  (ref) => ref.read(authServiceProvider).authStateChanges(),
 );
 
 final authProvider = Provider<FirebaseAuth>((ref) {

--- a/test/mocks/service_mocks.dart
+++ b/test/mocks/service_mocks.dart
@@ -1,6 +1,6 @@
 import 'package:mockito/annotations.dart';
 
-import '../../lib/core/auth_service.dart';
+import '../../lib/services/auth_service.dart';
 import '../../lib/infra/firestore_service.dart';
 import '../../lib/infra/firebase_storage_service.dart';
 

--- a/test/mocks/service_mocks.mocks.dart
+++ b/test/mocks/service_mocks.mocks.dart
@@ -1,6 +1,6 @@
 import 'package:mockito/mockito.dart';
 
-import '../../lib/core/auth_service.dart';
+import '../../lib/services/auth_service.dart';
 import '../../lib/infra/firestore_service.dart';
 import '../../lib/infra/firebase_storage_service.dart';
 


### PR DESCRIPTION
## Summary
- add simplified `AppUser` model
- move auth service to `services/` and expose auth state stream
- provide new routing in `AuthWrapper`
- expand routes with business entry, studio profile, child dashboard and unsupported screen
- add fallback screen for unsupported roles

## Testing
- `flutter analyze` *(fails: SDK version 3.3.0 < 3.4.0)*
- `flutter test` *(fails: SDK version 3.3.0 < 3.4.0)*

------
https://chatgpt.com/codex/tasks/task_e_686074c8ff6083249d8ee0426c1168f1