### PR TITLE
Implement studio CRUD flows

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -6,6 +6,9 @@ import '../features/studio/studio_booking_screen.dart';
 import '../features/studio/studio_booking_confirm_screen.dart';
 import '../features/studio/ui/content_library_screen.dart';
 import '../features/studio/ui/studio_dashboard_screen.dart';
+import '../features/studio/ui/appointments_screen.dart';
+import '../features/studio/ui/staff_screen.dart';
+import '../features/studio/ui/providers_screen.dart';
 import '../features/booking/screens/chat_booking_screen.dart';
 import '../features/booking/booking_request_screen.dart';
 import '../features/dashboard/dashboard_screen.dart';
@@ -67,6 +70,22 @@ class AppRouter {
       case '/studio/library':
         return MaterialPageRoute(
           builder: (_) => const ContentLibraryScreen(),
+          settings: settings,
+        );
+      case '/studio/appointments':
+        return MaterialPageRoute(
+          builder: (_) => const AppointmentsScreen(),
+          settings: settings,
+        );
+      case '/studio/staff':
+        final staffId = settings.arguments as String? ?? 'default';
+        return MaterialPageRoute(
+          builder: (_) => StaffScreen(staffId: staffId),
+          settings: settings,
+        );
+      case '/studio/providers':
+        return MaterialPageRoute(
+          builder: (_) => const ProvidersScreen(),
           settings: settings,
         );
       case '/chat-booking':

--- a/lib/features/studio/ui/appointments_screen.dart
+++ b/lib/features/studio/ui/appointments_screen.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../models/studio_appointment.dart';
+import '../../../providers/studio_appointments_provider.dart';
+
+class AppointmentsScreen extends ConsumerWidget {
+  const AppointmentsScreen({super.key});
+
+  Future<void> _openEditor(BuildContext context, WidgetRef ref,
+      {StudioAppointment? appt}) async {
+    final titleController = TextEditingController(text: appt?.title ?? '');
+    final clientController = TextEditingController(text: appt?.client ?? '');
+    final notesController = TextEditingController(text: appt?.notes ?? '');
+    DateTime? time = appt?.time ?? DateTime.now();
+
+    await showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(appt == null ? 'New Appointment' : 'Edit Appointment'),
+          content: StatefulBuilder(
+            builder: (context, setState) {
+              return SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    TextField(
+                      controller: titleController,
+                      decoration: const InputDecoration(labelText: 'Title'),
+                    ),
+                    TextField(
+                      controller: clientController,
+                      decoration: const InputDecoration(labelText: 'Client'),
+                    ),
+                    TextField(
+                      controller: notesController,
+                      decoration: const InputDecoration(labelText: 'Notes'),
+                    ),
+                    const SizedBox(height: 12),
+                    Row(
+                      children: [
+                        Text(time == null
+                            ? 'No time'
+                            : '${time.toLocal()}'.split('.').first),
+                        const Spacer(),
+                        TextButton(
+                          onPressed: () async {
+                            final date = await showDatePicker(
+                              context: context,
+                              initialDate: time ?? DateTime.now(),
+                              firstDate: DateTime(2020),
+                              lastDate: DateTime(2100),
+                            );
+                            if (date != null) {
+                              final t = await showTimePicker(
+                                context: context,
+                                initialTime: TimeOfDay.fromDateTime(
+                                    time ?? DateTime.now()),
+                              );
+                              if (t != null) {
+                                setState(() {
+                                  time = DateTime(date.year, date.month,
+                                      date.day, t.hour, t.minute);
+                                });
+                              }
+                            }
+                          },
+                          child: const Text('Pick Time'),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                final newAppt = StudioAppointment(
+                  id: appt?.id ?? '',
+                  title: titleController.text,
+                  time: time ?? DateTime.now(),
+                  client: clientController.text,
+                  notes: notesController.text,
+                );
+                if (appt == null) {
+                  ref.read(studioAppointmentsProvider.notifier).add(newAppt);
+                } else {
+                  ref.read(studioAppointmentsProvider.notifier).update(newAppt);
+                }
+                Navigator.pop(context);
+              },
+              child: const Text('Save'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final apptsAsync = ref.watch(studioAppointmentsProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Appointments'),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _openEditor(context, ref),
+        child: const Icon(Icons.add),
+      ),
+      body: apptsAsync.when(
+        data: (appts) {
+          if (appts.isEmpty) {
+            return const Center(child: Text('No appointments'));
+          }
+          return ListView.builder(
+            itemCount: appts.length,
+            itemBuilder: (context, index) {
+              final appt = appts[index];
+              return ListTile(
+                title: Text(appt.title),
+                subtitle: Text('${appt.client} – '
+                        '${appt.time.toLocal()}'
+                    .split('.')
+                    .first),
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.edit),
+                      onPressed: () => _openEditor(context, ref, appt: appt),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.delete),
+                      onPressed: () => ref
+                          .read(studioAppointmentsProvider.notifier)
+                          .delete(appt.id),
+                    ),
+                  ],
+                ),
+              );
+            },
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
+      ),
+    );
+  }
+}

--- a/lib/features/studio/ui/providers_screen.dart
+++ b/lib/features/studio/ui/providers_screen.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../models/care_provider.dart';
+import '../../../providers/care_providers_provider.dart';
+
+class ProvidersScreen extends ConsumerWidget {
+  const ProvidersScreen({super.key});
+
+  Future<void> _openEditor(BuildContext context, WidgetRef ref,
+      {CareProvider? provider}) async {
+    final nameController = TextEditingController(text: provider?.name ?? '');
+    final specialtyController =
+        TextEditingController(text: provider?.specialty ?? '');
+    final contactController =
+        TextEditingController(text: provider?.contactInfo ?? '');
+
+    await showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(provider == null ? 'Add Provider' : 'Edit Provider'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: nameController,
+                decoration: const InputDecoration(labelText: 'Name'),
+              ),
+              TextField(
+                controller: specialtyController,
+                decoration: const InputDecoration(labelText: 'Specialty'),
+              ),
+              TextField(
+                controller: contactController,
+                decoration: const InputDecoration(labelText: 'Contact Info'),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                final newProv = CareProvider(
+                  id: provider?.id ?? '',
+                  name: nameController.text,
+                  specialty: specialtyController.text,
+                  contactInfo: contactController.text,
+                );
+                if (provider == null) {
+                  ref.read(careProvidersProvider.notifier).add(newProv);
+                } else {
+                  ref.read(careProvidersProvider.notifier).update(newProv);
+                }
+                Navigator.pop(context);
+              },
+              child: const Text('Save'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final provsAsync = ref.watch(careProvidersProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Providers')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _openEditor(context, ref),
+        child: const Icon(Icons.add),
+      ),
+      body: provsAsync.when(
+        data: (provs) {
+          if (provs.isEmpty) {
+            return const Center(child: Text('No providers'));
+          }
+          return ListView.builder(
+            itemCount: provs.length,
+            itemBuilder: (context, index) {
+              final p = provs[index];
+              return ListTile(
+                title: Text(p.name),
+                subtitle: Text('${p.specialty}\n${p.contactInfo}'),
+                isThreeLine: true,
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.edit),
+                      onPressed: () => _openEditor(context, ref, provider: p),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.delete),
+                      onPressed: () =>
+                          ref.read(careProvidersProvider.notifier).delete(p.id),
+                    ),
+                  ],
+                ),
+              );
+            },
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
+      ),
+    );
+  }
+}

--- a/lib/features/studio/ui/staff_screen.dart
+++ b/lib/features/studio/ui/staff_screen.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../models/staff_availability.dart';
+import '../../../providers/staff_availability_crud_provider.dart';
+
+class StaffScreen extends ConsumerStatefulWidget {
+  final String staffId;
+  const StaffScreen({super.key, required this.staffId});
+
+  @override
+  ConsumerState<StaffScreen> createState() => _StaffScreenState();
+}
+
+class _StaffScreenState extends ConsumerState<StaffScreen> {
+  DateTime _selectedDate = DateTime.now();
+  final _slotController = TextEditingController();
+
+  Future<void> _addSlot() async {
+    final slot = _slotController.text;
+    if (slot.isEmpty) return;
+    final avail = StaffAvailability(
+      staffId: widget.staffId,
+      date: _selectedDate,
+      availableSlots: [slot],
+    );
+    await ref
+        .read(staffAvailabilityProvider(widget.staffId).notifier)
+        .save(avail);
+    _slotController.clear();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final availabilityAsync =
+        ref.watch(staffAvailabilityProvider(widget.staffId));
+    return Scaffold(
+      appBar: AppBar(title: const Text('Staff Availability')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Row(
+              children: [
+                Text('${_selectedDate.toLocal()}'.split(' ')[0]),
+                const Spacer(),
+                TextButton(
+                  onPressed: () async {
+                    final date = await showDatePicker(
+                      context: context,
+                      initialDate: _selectedDate,
+                      firstDate: DateTime(2020),
+                      lastDate: DateTime(2100),
+                    );
+                    if (date != null) {
+                      setState(() => _selectedDate = date);
+                    }
+                  },
+                  child: const Text('Pick Date'),
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _slotController,
+                    decoration: const InputDecoration(
+                      labelText: 'HH:MM',
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.add),
+                  onPressed: _addSlot,
+                )
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: availabilityAsync.when(
+              data: (list) {
+                final todays = list
+                    .where((a) =>
+                        a.date.year == _selectedDate.year &&
+                        a.date.month == _selectedDate.month &&
+                        a.date.day == _selectedDate.day)
+                    .toList();
+                if (todays.isEmpty) {
+                  return const Center(child: Text('No slots'));
+                }
+                final slots =
+                    todays.expand((a) => a.availableSlots ?? []).toList();
+                return ListView.builder(
+                  itemCount: slots.length,
+                  itemBuilder: (context, index) {
+                    final slot = slots[index];
+                    return ListTile(
+                      title: Text(slot),
+                      trailing: IconButton(
+                        icon: const Icon(Icons.delete),
+                        onPressed: () async {
+                          await ref
+                              .read(staffAvailabilityProvider(widget.staffId)
+                                  .notifier)
+                              .delete(_selectedDate);
+                        },
+                      ),
+                    );
+                  },
+                );
+              },
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (e, _) => Center(child: Text('Error: $e')),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/models/care_provider.dart
+++ b/lib/models/care_provider.dart
@@ -1,0 +1,43 @@
+class CareProvider {
+  final String id;
+  final String name;
+  final String specialty;
+  final String contactInfo;
+
+  CareProvider({
+    required this.id,
+    required this.name,
+    required this.specialty,
+    required this.contactInfo,
+  });
+
+  factory CareProvider.fromJson(Map<String, dynamic> json) {
+    return CareProvider(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      specialty: json['specialty'] as String,
+      contactInfo: json['contactInfo'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'specialty': specialty,
+        'contactInfo': contactInfo,
+      };
+
+  CareProvider copyWith({
+    String? id,
+    String? name,
+    String? specialty,
+    String? contactInfo,
+  }) {
+    return CareProvider(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      specialty: specialty ?? this.specialty,
+      contactInfo: contactInfo ?? this.contactInfo,
+    );
+  }
+}

--- a/lib/models/studio_appointment.dart
+++ b/lib/models/studio_appointment.dart
@@ -1,0 +1,49 @@
+class StudioAppointment {
+  final String id;
+  final String title;
+  final DateTime time;
+  final String client;
+  final String? notes;
+
+  StudioAppointment({
+    required this.id,
+    required this.title,
+    required this.time,
+    required this.client,
+    this.notes,
+  });
+
+  factory StudioAppointment.fromJson(Map<String, dynamic> json) {
+    return StudioAppointment(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      time: DateTime.parse(json['time'] as String),
+      client: json['client'] as String,
+      notes: json['notes'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'title': title,
+        'time': time.toIso8601String(),
+        'client': client,
+        'notes': notes,
+      };
+
+  StudioAppointment copyWith({
+    String? id,
+    String? title,
+    DateTime? time,
+    String? client,
+    String? notes,
+  }) {
+    return StudioAppointment(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      time: time ?? this.time,
+      client: client ?? this.client,
+      notes: notes ?? this.notes,
+    );
+  }
+}

--- a/lib/providers/care_providers_provider.dart
+++ b/lib/providers/care_providers_provider.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/care_provider.dart';
+import '../services/care_provider_service.dart';
+
+final careProviderServiceProvider =
+    Provider<CareProviderService>((ref) => CareProviderService());
+
+class CareProvidersNotifier
+    extends StateNotifier<AsyncValue<List<CareProvider>>> {
+  final CareProviderService _service;
+  CareProvidersNotifier(this._service) : super(const AsyncValue.loading()) {
+    load();
+  }
+
+  Future<void> load() async {
+    try {
+      final data = await _service.fetchProviders();
+      state = AsyncValue.data(data);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  Future<void> add(CareProvider provider) async {
+    await _service.addProvider(provider);
+    await load();
+  }
+
+  Future<void> update(CareProvider provider) async {
+    await _service.updateProvider(provider);
+    await load();
+  }
+
+  Future<void> delete(String id) async {
+    await _service.deleteProvider(id);
+    await load();
+  }
+}
+
+final careProvidersProvider = StateNotifierProvider<CareProvidersNotifier,
+    AsyncValue<List<CareProvider>>>(
+  (ref) => CareProvidersNotifier(ref.read(careProviderServiceProvider)),
+);

--- a/lib/providers/staff_availability_crud_provider.dart
+++ b/lib/providers/staff_availability_crud_provider.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/staff_availability.dart';
+import '../services/staff_availability_service.dart';
+
+final staffAvailabilityServiceProvider =
+    Provider<StaffAvailabilityService>((ref) => StaffAvailabilityService());
+
+class StaffAvailabilityNotifier
+    extends StateNotifier<AsyncValue<List<StaffAvailability>>> {
+  final StaffAvailabilityService _service;
+  final String staffId;
+  StaffAvailabilityNotifier(this._service, this.staffId)
+      : super(const AsyncValue.loading()) {
+    load();
+  }
+
+  Future<void> load() async {
+    try {
+      final data = await _service.fetchAvailability(staffId);
+      state = AsyncValue.data(data);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  Future<void> save(StaffAvailability avail) async {
+    await _service.saveAvailability(avail);
+    await load();
+  }
+
+  Future<void> delete(DateTime date) async {
+    await _service.deleteAvailability(staffId, date);
+    await load();
+  }
+}
+
+final staffAvailabilityProvider = StateNotifierProvider.family<
+    StaffAvailabilityNotifier, AsyncValue<List<StaffAvailability>>, String>(
+  (ref, staffId) => StaffAvailabilityNotifier(
+      ref.read(staffAvailabilityServiceProvider), staffId),
+);

--- a/lib/providers/studio_appointments_provider.dart
+++ b/lib/providers/studio_appointments_provider.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/studio_appointment.dart';
+import '../services/studio_appointment_service.dart';
+
+final studioAppointmentServiceProvider =
+    Provider<StudioAppointmentService>((ref) => StudioAppointmentService());
+
+class StudioAppointmentsNotifier
+    extends StateNotifier<AsyncValue<List<StudioAppointment>>> {
+  final StudioAppointmentService _service;
+  StudioAppointmentsNotifier(this._service)
+      : super(const AsyncValue.loading()) {
+    load();
+  }
+
+  Future<void> load() async {
+    try {
+      final data = await _service.fetchAppointments();
+      state = AsyncValue.data(data);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  Future<void> add(StudioAppointment appt) async {
+    await _service.addAppointment(appt);
+    await load();
+  }
+
+  Future<void> update(StudioAppointment appt) async {
+    await _service.updateAppointment(appt);
+    await load();
+  }
+
+  Future<void> delete(String id) async {
+    await _service.deleteAppointment(id);
+    await load();
+  }
+}
+
+final studioAppointmentsProvider = StateNotifierProvider<
+    StudioAppointmentsNotifier, AsyncValue<List<StudioAppointment>>>(
+  (ref) =>
+      StudioAppointmentsNotifier(ref.read(studioAppointmentServiceProvider)),
+);

--- a/lib/services/care_provider_service.dart
+++ b/lib/services/care_provider_service.dart
@@ -1,0 +1,31 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/care_provider.dart';
+
+class CareProviderService {
+  final FirebaseFirestore _firestore;
+  CareProviderService({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  CollectionReference<Map<String, dynamic>> get _col =>
+      _firestore.collection('care_providers');
+
+  Future<List<CareProvider>> fetchProviders() async {
+    final snap = await _col.get();
+    return snap.docs
+        .map((d) => CareProvider.fromJson({...d.data(), 'id': d.id}))
+        .toList();
+  }
+
+  Future<void> addProvider(CareProvider provider) async {
+    final doc = _col.doc(provider.id.isEmpty ? null : provider.id);
+    await doc.set(provider.copyWith(id: doc.id).toJson());
+  }
+
+  Future<void> updateProvider(CareProvider provider) async {
+    await _col.doc(provider.id).set(provider.toJson());
+  }
+
+  Future<void> deleteProvider(String id) async {
+    await _col.doc(id).delete();
+  }
+}

--- a/lib/services/staff_availability_service.dart
+++ b/lib/services/staff_availability_service.dart
@@ -1,0 +1,28 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/staff_availability.dart';
+
+class StaffAvailabilityService {
+  final FirebaseFirestore _firestore;
+  StaffAvailabilityService({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  CollectionReference<Map<String, dynamic>> _col(String staffId) =>
+      _firestore.collection('staff/$staffId/availability');
+
+  Future<List<StaffAvailability>> fetchAvailability(String staffId) async {
+    final snap = await _col(staffId).get();
+    return snap.docs
+        .map((d) =>
+            StaffAvailability.fromJson({...d.data(), 'staffId': staffId}))
+        .toList();
+  }
+
+  Future<void> saveAvailability(StaffAvailability avail) async {
+    final doc = _col(avail.staffId).doc(avail.date.toIso8601String());
+    await doc.set(avail.toJson());
+  }
+
+  Future<void> deleteAvailability(String staffId, DateTime date) async {
+    await _col(staffId).doc(date.toIso8601String()).delete();
+  }
+}

--- a/lib/services/studio_appointment_service.dart
+++ b/lib/services/studio_appointment_service.dart
@@ -1,0 +1,31 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/studio_appointment.dart';
+
+class StudioAppointmentService {
+  final FirebaseFirestore _firestore;
+  StudioAppointmentService({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  CollectionReference<Map<String, dynamic>> get _col =>
+      _firestore.collection('studio_appointments');
+
+  Future<List<StudioAppointment>> fetchAppointments() async {
+    final snap = await _col.get();
+    return snap.docs
+        .map((d) => StudioAppointment.fromJson({...d.data(), 'id': d.id}))
+        .toList();
+  }
+
+  Future<void> addAppointment(StudioAppointment appt) async {
+    final doc = _col.doc(appt.id.isEmpty ? null : appt.id);
+    await doc.set(appt.copyWith(id: doc.id).toJson());
+  }
+
+  Future<void> updateAppointment(StudioAppointment appt) async {
+    await _col.doc(appt.id).set(appt.toJson());
+  }
+
+  Future<void> deleteAppointment(String id) async {
+    await _col.doc(id).delete();
+  }
+}


### PR DESCRIPTION
## Summary
- add studio appointment, staff availability, and provider models/services
- wire up new providers for studio CRUD operations
- create UI screens for appointments, staff availability, and providers
- hook up new screens to routes

## Testing
- `dart format` (using flutter sdk)
- `dart test --coverage` *(fails: storage.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6860788d73e08324b6995baa8ff8192d