### PR TITLE
Improve responsiveness and onboarding

### DIFF
--- a/lib/features/dashboard/dashboard_screen.dart
+++ b/lib/features/dashboard/dashboard_screen.dart
@@ -6,7 +6,9 @@ import '../../l10n/app_localizations.dart';
 import '../../widgets/app_scaffold.dart';
 import '../../widgets/loading_state.dart';
 import '../../widgets/error_state.dart';
+import '../../widgets/responsive_scaffold.dart';
 import '../../theme/app_spacing.dart';
+import '../../theme/app_breakpoints.dart';
 
 class DashboardScreen extends ConsumerWidget {
   const DashboardScreen({super.key});
@@ -20,35 +22,35 @@ class DashboardScreen extends ConsumerWidget {
       title: l10n.dashboard,
       body: statsAsync.when(
         data: (stats) {
-          return Padding(
-            padding: const EdgeInsets.all(AppSpacing.md),
-            child: Column(
-              children: [
-                Card(
-                  child: ListTile(
-                    title: Text('Total Appointments'),
-                    subtitle: Text('${stats.totalAppointments}'),
-                  ),
-                ),
-                Card(
-                  child: ListTile(
-                    title: Text('Completed Appointments'),
-                    subtitle: Text('${stats.completedAppointments}'),
-                  ),
-                ),
-                Card(
-                  child: ListTile(
-                    title: Text('Pending Invites'),
-                    subtitle: Text('${stats.pendingInvites}'),
-                  ),
-                ),
-                Card(
-                  child: ListTile(
-                    title: Text('Revenue'),
-                    subtitle: Text('\$${stats.revenue.toStringAsFixed(2)}'),
-                  ),
-                ),
-              ],
+          final cards = [
+            _StatsCard(
+                title: 'Total Appointments',
+                value: '${stats.totalAppointments}'),
+            _StatsCard(
+                title: 'Completed Appointments',
+                value: '${stats.completedAppointments}'),
+            _StatsCard(
+                title: 'Pending Invites', value: '${stats.pendingInvites}'),
+            _StatsCard(
+                title: 'Revenue',
+                value: '\$${stats.revenue.toStringAsFixed(2)}'),
+          ];
+
+          return ResponsiveScaffold(
+            mobile: Column(children: cards),
+            tablet: GridView.count(
+              crossAxisCount: 2,
+              crossAxisSpacing: AppSpacing.md,
+              mainAxisSpacing: AppSpacing.md,
+              shrinkWrap: true,
+              children: cards,
+            ),
+            desktop: GridView.count(
+              crossAxisCount: 4,
+              crossAxisSpacing: AppSpacing.md,
+              mainAxisSpacing: AppSpacing.md,
+              shrinkWrap: true,
+              children: cards,
             ),
           );
         },
@@ -57,6 +59,23 @@ class DashboardScreen extends ConsumerWidget {
           title: 'Error',
           description: 'Error loading stats',
         ),
+      ),
+    );
+  }
+}
+
+class _StatsCard extends StatelessWidget {
+  const _StatsCard({required this.title, required this.value});
+
+  final String title;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        title: Text(title),
+        subtitle: Text(value),
       ),
     );
   }

--- a/lib/theme/app_breakpoints.dart
+++ b/lib/theme/app_breakpoints.dart
@@ -1,0 +1,8 @@
+/// Breakpoints used for responsive layouts.
+class AppBreakpoints {
+  AppBreakpoints._();
+
+  static const double mobile = 600;
+  static const double tablet = 1024;
+  static const double desktop = 1440;
+}

--- a/lib/widgets/accessibility/semantic_button.dart
+++ b/lib/widgets/accessibility/semantic_button.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+/// Button with proper semantics and minimum tap target.
+class SemanticButton extends StatelessWidget {
+  const SemanticButton({
+    super.key,
+    required this.onPressed,
+    required this.label,
+    required this.child,
+  });
+
+  final VoidCallback onPressed;
+  final String label;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: label,
+      child: InkWell(
+        onTap: onPressed,
+        borderRadius: BorderRadius.circular(4),
+        hoverColor: Theme.of(context).colorScheme.primary.withOpacity(0.1),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 48, minWidth: 48),
+          child: Center(child: child),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/feedback/animated_wrapper.dart
+++ b/lib/widgets/feedback/animated_wrapper.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+/// Wraps child with fade and slide transition when it changes.
+class AnimatedWrapper extends StatelessWidget {
+  const AnimatedWrapper({
+    super.key,
+    required this.child,
+    this.duration = const Duration(milliseconds: 300),
+    this.direction = AxisDirection.down,
+  });
+
+  final Widget child;
+  final Duration duration;
+  final AxisDirection direction;
+
+  Offset _offsetForDirection(AxisDirection direction) {
+    switch (direction) {
+      case AxisDirection.up:
+        return const Offset(0, 0.1);
+      case AxisDirection.down:
+        return const Offset(0, -0.1);
+      case AxisDirection.left:
+        return const Offset(0.1, 0);
+      case AxisDirection.right:
+        return const Offset(-0.1, 0);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: duration,
+      transitionBuilder: (child, animation) {
+        final offsetAnimation = Tween<Offset>(
+                begin: _offsetForDirection(direction), end: Offset.zero)
+            .animate(animation);
+        return SlideTransition(
+          position: offsetAnimation,
+          child: FadeTransition(opacity: animation, child: child),
+        );
+      },
+      child: child,
+    );
+  }
+}

--- a/lib/widgets/onboarding/onboarding_screen.dart
+++ b/lib/widgets/onboarding/onboarding_screen.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+
+/// Simple onboarding flow with progress indicator and skip/next buttons.
+class OnboardingScreen extends StatefulWidget {
+  const OnboardingScreen({super.key});
+
+  @override
+  State<OnboardingScreen> createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends State<OnboardingScreen> {
+  final PageController _controller = PageController();
+  int _index = 0;
+
+  final List<_OnboardingPage> _pages = const [
+    _OnboardingPage(title: 'Welcome', description: 'Welcome to Appoint!'),
+    _OnboardingPage(
+        title: 'Core Features', description: 'Discover the core features.'),
+    _OnboardingPage(
+        title: 'Scheduling Flow', description: 'Easily schedule appointments.'),
+    _OnboardingPage(
+        title: 'Upgrade Plan', description: 'Upgrade anytime for more.'),
+  ];
+
+  void _next() {
+    if (_index < _pages.length - 1) {
+      _controller.nextPage(
+          duration: const Duration(milliseconds: 300), curve: Curves.easeOut);
+    } else {
+      OnboardingPrefs.setCompleted();
+      Navigator.of(context).pop();
+    }
+  }
+
+  void _skip() {
+    OnboardingPrefs.setCompleted();
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: PageView(
+                controller: _controller,
+                onPageChanged: (i) => setState(() => _index = i),
+                children: _pages,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  if (_index < _pages.length - 1)
+                    TextButton(onPressed: _skip, child: const Text('Skip'))
+                  else
+                    const SizedBox(width: 60),
+                  Row(
+                    children: List.generate(
+                      _pages.length,
+                      (i) => Container(
+                        width: 8,
+                        height: 8,
+                        margin: const EdgeInsets.all(4),
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: i == _index ? Colors.black : Colors.grey,
+                        ),
+                      ),
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: _next,
+                    child:
+                        Text(_index == _pages.length - 1 ? 'Finish' : 'Next'),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _OnboardingPage extends StatelessWidget {
+  const _OnboardingPage({required this.title, required this.description});
+
+  final String title;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(32),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(title, style: Theme.of(context).textTheme.headlineMedium),
+          const SizedBox(height: 16),
+          Text(
+            description,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodyLarge,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Mock storage for onboarding completion.
+class OnboardingPrefs {
+  static bool _completed = false;
+  static Future<bool> isCompleted() async => _completed;
+  static Future<void> setCompleted() async {
+    _completed = true;
+  }
+}

--- a/lib/widgets/responsive_scaffold.dart
+++ b/lib/widgets/responsive_scaffold.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import '../theme/app_breakpoints.dart';
+import '../theme/app_spacing.dart';
 
 /// Simple scaffold that renders different layouts based on width breakpoints.
 class ResponsiveScaffold extends StatelessWidget {
@@ -18,18 +20,28 @@ class ResponsiveScaffold extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final width = constraints.maxWidth;
-        if (width >= 1024 && desktop != null) {
+        if (width >= AppBreakpoints.desktop && desktop != null) {
           return SafeArea(
-              child:
-                  Padding(padding: const EdgeInsets.all(16), child: desktop!));
+            child: Padding(
+              padding: const EdgeInsets.all(AppSpacing.md),
+              child: desktop!,
+            ),
+          );
         }
-        if (width >= 600 && tablet != null) {
+        if (width >= AppBreakpoints.tablet && tablet != null) {
           return SafeArea(
-              child:
-                  Padding(padding: const EdgeInsets.all(16), child: tablet!));
+            child: Padding(
+              padding: const EdgeInsets.all(AppSpacing.md),
+              child: tablet!,
+            ),
+          );
         }
         return SafeArea(
-            child: Padding(padding: const EdgeInsets.all(16), child: mobile));
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: mobile,
+          ),
+        );
       },
     );
   }


### PR DESCRIPTION
## Summary
- add breakpoint constants
- add semantic button widget
- add animated wrapper helper
- add onboarding screen with page view
- use breakpoints in responsive scaffold
- refactor dashboard screen for responsive layout

## Testing
- `dart test --coverage` *(fails: network access to storage.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686082e68f348324b68a79dfa65f99a6