### PR TITLE
Add test scaffolds

### DIFF
--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SettingsScreen', () {
+    setUp(() {
+      // TODO: Initialize test dependencies
+    });
+
+    testWidgets('renders correctly', (tester) async {
+      // TODO: implement widget test
+    });
+  });
+}

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('NotificationService', () {
+    setUp(() {
+      // TODO: Set up NotificationService tests
+    });
+
+    testWidgets('initializes correctly', (tester) async {
+      // TODO: implement service test
+    });
+  });
+}

--- a/test/widgets/bottom_sheet_test.dart
+++ b/test/widgets/bottom_sheet_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('BottomSheet', () {
+    setUp(() {
+      // TODO: Prepare bottom sheet widget tests
+    });
+
+    testWidgets('opens and closes correctly', (tester) async {
+      // TODO: implement bottom sheet widget test
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add placeholder test for SettingsScreen
- add placeholder test for NotificationService
- add placeholder test for bottom sheet widget

## Testing
- `dart test --coverage` *(fails: storage.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6860862713e48324ad7c7f6a1632e863