### PR TITLE
Add TimezoneSelector widget

### DIFF
--- a/lib/widgets/timezone_selector.dart
+++ b/lib/widgets/timezone_selector.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+import '../theme/app_spacing.dart';
+import '../theme/app_text_styles.dart';
+
+/// Dropdown widget to select a timezone using Material 3 styling.
+class TimezoneSelector extends StatefulWidget {
+  const TimezoneSelector({super.key});
+
+  @override
+  State<TimezoneSelector> createState() => _TimezoneSelectorState();
+}
+
+class _TimezoneSelectorState extends State<TimezoneSelector> {
+  static const List<String> _timezones = [
+    'UTC',
+    'America/New_York',
+    'America/Chicago',
+    'America/Denver',
+    'America/Los_Angeles',
+    'Europe/London',
+    'Europe/Paris',
+    'Asia/Tokyo',
+    'Asia/Kolkata',
+    'Australia/Sydney',
+  ];
+
+  String? _selectedTimezone;
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownButtonFormField<String>(
+      decoration: const InputDecoration(
+        labelText: 'Timezone',
+        border: OutlineInputBorder(),
+        contentPadding: EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+          vertical: AppSpacing.sm,
+        ),
+      ),
+      value: _selectedTimezone,
+      style: AppTextStyles.body,
+      items: _timezones
+          .map((tz) => DropdownMenuItem(value: tz, child: Text(tz)))
+          .toList(),
+      onChanged: (value) {
+        setState(() {
+          _selectedTimezone = value;
+        });
+        if (value != null) {
+          debugPrint('Selected timezone: $value');
+        }
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add new `TimezoneSelector` widget with a dropdown of hard-coded timezones

## Testing
- `flutter pub get` *(fails: Dart SDK 3.3.0 < required 3.4.0)*
- `dart test --coverage` *(fails: Dart SDK 3.3.0 < required 3.4.0)*

------
https://chatgpt.com/codex/tasks/task_e_686086448e408324b4b019e4a044c425