### PR TITLE
Add BottomSheetManager utility

### DIFF
--- a/lib/features/playtime/playtime_hub_screen.dart
+++ b/lib/features/playtime/playtime_hub_screen.dart
@@ -7,6 +7,7 @@ import '../../providers/playtime_provider.dart';
 import '../../config/theme.dart';
 import '../../models/playtime_game.dart';
 import '../../models/playtime_session.dart';
+import '../../widgets/bottom_sheet_manager.dart';
 
 class PlaytimeHubScreen extends ConsumerWidget {
   const PlaytimeHubScreen({super.key});
@@ -475,12 +476,9 @@ class PlaytimeHubScreen extends ConsumerWidget {
   }
 
   void _showCreateOptions(BuildContext context, AppLocalizations l10n) {
-    showModalBottomSheet(
+    BottomSheetManager.show(
       context: context,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-      ),
-      builder: (context) => Container(
+      child: Container(
         padding: const EdgeInsets.all(20),
         child: Column(
           mainAxisSize: MainAxisSize.min,

--- a/lib/features/playtime/screens/game_list_screen.dart
+++ b/lib/features/playtime/screens/game_list_screen.dart
@@ -6,6 +6,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../providers/playtime_provider.dart';
 import '../../../config/theme.dart';
 import '../../../models/playtime_game.dart';
+import '../../../widgets/bottom_sheet_manager.dart';
 
 class GameListScreen extends ConsumerStatefulWidget {
   const GameListScreen({super.key});
@@ -336,12 +337,9 @@ class _GameListScreenState extends ConsumerState<GameListScreen> {
 
   void _showPlayOptions(
       BuildContext context, PlaytimeGame game, AppLocalizations l10n) {
-    showModalBottomSheet(
+    BottomSheetManager.show(
       context: context,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-      ),
-      builder: (context) => Container(
+      child: Container(
         padding: const EdgeInsets.all(20),
         child: Column(
           mainAxisSize: MainAxisSize.min,

--- a/lib/features/playtime/widgets/custom_background_picker.dart
+++ b/lib/features/playtime/widgets/custom_background_picker.dart
@@ -4,6 +4,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'dart:io';
 import 'package:firebase_auth/firebase_auth.dart';
+import '../../../widgets/bottom_sheet_manager.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../config/theme.dart';
@@ -290,13 +291,9 @@ class _CustomBackgroundPickerState
   }
 
   void _showUploadDialog() {
-    showModalBottomSheet(
+    BottomSheetManager.show(
       context: context,
-      isScrollControlled: true,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-      ),
-      builder: (context) => _UploadBackgroundDialog(
+      child: _UploadBackgroundDialog(
         onBackgroundUploaded: (backgroundId) {
           setState(() {
             _selectedBackgroundId = backgroundId;

--- a/lib/widgets/bottom_sheet_manager.dart
+++ b/lib/widgets/bottom_sheet_manager.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+/// Utility for displaying consistent modal bottom sheets across the app.
+class BottomSheetManager {
+  /// Shows a modal bottom sheet with the given [child] widget.
+  static Future<T?> show<T>({
+    required BuildContext context,
+    required Widget child,
+    bool isDismissible = true,
+    bool useSafeArea = true,
+  }) {
+    return showModalBottomSheet<T>(
+      context: context,
+      isScrollControlled: true,
+      isDismissible: isDismissible,
+      useSafeArea: useSafeArea,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (_) => Padding(
+        padding: MediaQuery.of(context).viewInsets,
+        child: child,
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- create a `BottomSheetManager` helper for consistent bottom sheets
- switch existing playtime widgets to use the new manager

## Testing
- `dart test --coverage` *(fails: The current Dart SDK version is 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_686088cff35483248fa7b2c3b61ae445