### PR TITLE
Implement consistent booking confirmation sheet

### DIFF
--- a/lib/features/studio/studio_booking_confirm_screen.dart
+++ b/lib/features/studio/studio_booking_confirm_screen.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import '../../widgets/bottom_sheet_manager.dart';
+import '../../widgets/booking_confirmation_sheet.dart';
 import 'studio_booking_screen.dart';
 
 class StudioBookingConfirmScreen extends ConsumerWidget {
@@ -21,7 +25,22 @@ class StudioBookingConfirmScreen extends ConsumerWidget {
             Text('Time: ${args.slot.format(context)}'),
             const Spacer(),
             ElevatedButton(
-              onPressed: () => Navigator.pop(context),
+              onPressed: () async {
+                final summaryText = 'You are about to book a session on '
+                    '${DateFormat.yMMMd().format(args.date)} at '
+                    '${args.slot.format(context)} with ${args.staff.displayName}.';
+                await BottomSheetManager.show(
+                  context: context,
+                  child: BookingConfirmationSheet(
+                    summaryText: summaryText,
+                    onCancel: () => Navigator.of(context).pop(),
+                    onConfirm: () {
+                      Navigator.of(context).pop();
+                      Navigator.pop(context);
+                    },
+                  ),
+                );
+              },
               child: const Text('Confirm Booking'),
             ),
           ],

--- a/lib/widgets/booking_confirmation_sheet.dart
+++ b/lib/widgets/booking_confirmation_sheet.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+class BookingConfirmationSheet extends StatelessWidget {
+  final VoidCallback onConfirm;
+  final VoidCallback onCancel;
+  final String summaryText;
+
+  const BookingConfirmationSheet({
+    required this.onConfirm,
+    required this.onCancel,
+    required this.summaryText,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Confirm Appointment',
+              style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 12),
+          Text(summaryText),
+          const SizedBox(height: 24),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: onCancel,
+                  child: const Text('Cancel'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: onConfirm,
+                  child: const Text('Confirm'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/bottom_sheet_manager.dart
+++ b/lib/widgets/bottom_sheet_manager.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class BottomSheetManager {
+  static Future<T?> show<T>({
+    required BuildContext context,
+    required Widget child,
+  }) {
+    return showModalBottomSheet<T>(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (context) => SafeArea(child: child),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `BottomSheetManager` utility for showing modal sheets
- create `BookingConfirmationSheet`
- use confirmation sheet when submitting a booking
- show confirmation sheet in studio booking flow

## Testing
- `flutter pub get`
- `dart test --coverage` *(fails: SDK version 3.3.0 < 3.4.0)*

------
https://chatgpt.com/codex/tasks/task_e_6860896ccfd4832498d4db40f08a43d9