### PR TITLE
Add bottom sheet confirmation for bookings

### DIFF
--- a/lib/features/booking/screens/booking_screen.dart
+++ b/lib/features/booking/screens/booking_screen.dart
@@ -4,6 +4,8 @@ import '../../../models/booking.dart';
 import '../services/booking_service.dart';
 import '../../../providers/auth_provider.dart';
 import '../../selection/providers/selection_provider.dart';
+import '../../../widgets/bottom_sheet_manager.dart';
+import '../../../widgets/booking_confirmation_sheet.dart';
 
 class BookingScreen extends ConsumerStatefulWidget {
   const BookingScreen({super.key});
@@ -111,7 +113,24 @@ class _BookingScreenState extends ConsumerState<BookingScreen> {
                       serviceId != null &&
                       dateTime != null &&
                       duration != null)
-                  ? (_isSubmitting ? null : _submitBooking)
+                  ? (_isSubmitting
+                      ? null
+                      : () {
+                          final summary =
+                              'You are about to book a ${duration!.inMinutes} minute appointment on '
+                              '${dateTime!.toLocal()}.';
+                          BottomSheetManager.show(
+                            context: context,
+                            child: BookingConfirmationSheet(
+                              summaryText: summary,
+                              onCancel: () => Navigator.of(context).pop(),
+                              onConfirm: () {
+                                Navigator.of(context).pop();
+                                _submitBooking();
+                              },
+                            ),
+                          );
+                        })
                   : null,
               child: _isSubmitting
                   ? const CircularProgressIndicator()

--- a/lib/features/studio/studio_booking_confirm_screen.dart
+++ b/lib/features/studio/studio_booking_confirm_screen.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../providers/appointment_provider.dart';
+import '../../providers/auth_provider.dart';
 import 'studio_booking_screen.dart';
+import '../../widgets/bottom_sheet_manager.dart';
+import '../../widgets/booking_confirmation_sheet.dart';
 
 class StudioBookingConfirmScreen extends ConsumerWidget {
   const StudioBookingConfirmScreen({Key? key}) : super(key: key);
@@ -21,7 +25,41 @@ class StudioBookingConfirmScreen extends ConsumerWidget {
             Text('Time: ${args.slot.format(context)}'),
             const Spacer(),
             ElevatedButton(
-              onPressed: () => Navigator.pop(context),
+              onPressed: () {
+                final summary =
+                    'You are about to book with ${args.staff.displayName} on '
+                    '${args.date.toLocal().toString().split(' ')[0]} at '
+                    '${args.slot.format(context)}.';
+                BottomSheetManager.show(
+                  context: context,
+                  child: BookingConfirmationSheet(
+                    summaryText: summary,
+                    onCancel: () => Navigator.of(context).pop(),
+                    onConfirm: () async {
+                      Navigator.of(context).pop();
+                      final user =
+                          await ref.read(authServiceProvider).currentUser();
+                      if (user == null) return;
+                      await ref
+                          .read(appointmentServiceProvider)
+                          .createScheduled(
+                            creatorId: user.uid,
+                            inviteeId: args.staff.id,
+                            scheduledAt: DateTime(
+                              args.date.year,
+                              args.date.month,
+                              args.date.day,
+                              args.slot.hour,
+                              args.slot.minute,
+                            ),
+                          );
+                      if (context.mounted) {
+                        Navigator.popUntil(context, ModalRoute.withName('/'));
+                      }
+                    },
+                  ),
+                );
+              },
               child: const Text('Confirm Booking'),
             ),
           ],

--- a/lib/widgets/booking_confirmation_sheet.dart
+++ b/lib/widgets/booking_confirmation_sheet.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+class BookingConfirmationSheet extends StatelessWidget {
+  final VoidCallback onConfirm;
+  final VoidCallback onCancel;
+  final String summaryText;
+
+  const BookingConfirmationSheet({
+    required this.onConfirm,
+    required this.onCancel,
+    required this.summaryText,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Confirm Appointment',
+              style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 12),
+          Text(summaryText),
+          const SizedBox(height: 24),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: onCancel,
+                  child: const Text('Cancel'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: onConfirm,
+                  child: const Text('Confirm'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/bottom_sheet_manager.dart
+++ b/lib/widgets/bottom_sheet_manager.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class BottomSheetManager {
+  static Future<T?> show<T>({
+    required BuildContext context,
+    required Widget child,
+  }) {
+    return showModalBottomSheet<T>(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (context) => SafeArea(child: child),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add shared `BottomSheetManager`
- create `BookingConfirmationSheet` widget
- use bottom sheet confirmation in personal booking flow
- prompt confirmation for studio bookings

## Testing
- `dart test --coverage` *(fails: Dart SDK version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_68608987160883249808c1cabb8b7b02