### PR TITLE
Add missing packages

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,9 +50,12 @@ dependencies:
   shadcn_ui: 0.15.2
   tailwind_colors: ^0.3.1
   syncfusion_flutter_charts: 28.2.6
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   integration_test: ^1.0.0
+  mocktail: ^1.0.3
+  fake_cloud_firestore: ^2.4.1
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- add `shared_preferences` to runtime dependencies
- add `mocktail` and `fake_cloud_firestore` for testing

## Testing
- `flutter pub get` *(fails: The current Dart SDK version is 3.3.0)*
- `/workspace/flutter_sdk/bin/dart test --coverage` *(fails: version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_6861cdb531fc8324a494e03fc852bfb9