### PR TITLE
Add runtime theme customization

### DIFF
--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -1,23 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../providers/theme_provider.dart';
 import '../../theme/app_spacing.dart';
+import '../../theme/sample_palettes.dart';
 import '../../widgets/app_scaffold.dart';
 
 /// Static settings screen with dummy toggles.
-class SettingsScreen extends StatefulWidget {
+class SettingsScreen extends ConsumerStatefulWidget {
   const SettingsScreen({super.key});
 
   @override
-  State<SettingsScreen> createState() => _SettingsScreenState();
+  ConsumerState<SettingsScreen> createState() => _SettingsScreenState();
 }
 
-class _SettingsScreenState extends State<SettingsScreen> {
+class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   bool _notifications = false;
   bool _vibration = false;
-  bool _darkMode = false;
 
   @override
   Widget build(BuildContext context) {
+    final palette = ref.watch(themeNotifierProvider).palette;
+    final darkMode = ref.watch(themeModeProvider) == ThemeMode.dark;
+
     return AppScaffold(
       title: 'Settings',
       body: Padding(
@@ -38,8 +43,29 @@ class _SettingsScreenState extends State<SettingsScreen> {
             const SizedBox(height: AppSpacing.sm),
             SwitchListTile(
               title: const Text('Dark Mode'),
-              value: _darkMode,
-              onChanged: (value) => setState(() => _darkMode = value),
+              value: darkMode,
+              onChanged: (value) {
+                ref
+                    .read(themeNotifierProvider.notifier)
+                    .setMode(value ? ThemeMode.dark : ThemeMode.light);
+              },
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            DropdownButton<AppPalette>(
+              value: palette,
+              onChanged: (value) {
+                if (value != null) {
+                  ref.read(themeNotifierProvider.notifier).setPalette(value);
+                }
+              },
+              items: AppPalette.values
+                  .map(
+                    (p) => DropdownMenuItem(
+                      value: p,
+                      child: Text(p.name),
+                    ),
+                  )
+                  .toList(),
             ),
           ],
         ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'l10n/app_localizations.dart';
 import 'config/routes.dart';
 import 'theme/app_theme.dart';
+import 'providers/theme_provider.dart';
 import 'firebase_options.dart';
 import 'services/custom_deep_link_service.dart';
 import 'services/notification_service.dart';
@@ -66,16 +67,16 @@ void main() {
   appMain();
 }
 
-class MyApp extends StatefulWidget {
+class MyApp extends ConsumerStatefulWidget {
   final CustomDeepLinkService deepLinkService;
 
   const MyApp({Key? key, required this.deepLinkService}) : super(key: key);
 
   @override
-  State<MyApp> createState() => _MyAppState();
+  ConsumerState<MyApp> createState() => _MyAppState();
 }
 
-class _MyAppState extends State<MyApp> {
+class _MyAppState extends ConsumerState<MyApp> {
   final GlobalKey<NavigatorState> _navigatorKey = GlobalKey<NavigatorState>();
 
   @override
@@ -93,11 +94,15 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
+    final lightTheme = ref.watch(lightThemeProvider);
+    final darkTheme = ref.watch(darkThemeProvider);
+    final themeMode = ref.watch(themeModeProvider);
+
     return MaterialApp(
       title: 'APP-OINT',
-      theme: AppTheme.lightTheme,
-      darkTheme: AppTheme.darkTheme,
-      themeMode: ThemeMode.system,
+      theme: lightTheme,
+      darkTheme: darkTheme,
+      themeMode: themeMode,
       navigatorKey: _navigatorKey,
       onGenerateRoute: AppRouter.onGenerateRoute,
       navigatorObservers: [

--- a/lib/providers/theme_provider.dart
+++ b/lib/providers/theme_provider.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../theme/app_theme.dart';
+import '../theme/sample_palettes.dart';
+import '../theme/app_colors.dart';
+
+/// Holds the currently selected palette and theme mode.
+class ThemeState {
+  final AppPalette palette;
+  final ThemeMode mode;
+  const ThemeState({required this.palette, required this.mode});
+
+  ThemeState copyWith({AppPalette? palette, ThemeMode? mode}) => ThemeState(
+        palette: palette ?? this.palette,
+        mode: mode ?? this.mode,
+      );
+}
+
+class ThemeNotifier extends StateNotifier<ThemeState> {
+  ThemeNotifier()
+      : super(
+            const ThemeState(palette: AppPalette.blue, mode: ThemeMode.system));
+
+  void setPalette(AppPalette palette) {
+    state = state.copyWith(palette: palette);
+  }
+
+  void setMode(ThemeMode mode) {
+    state = state.copyWith(mode: mode);
+  }
+}
+
+final themeNotifierProvider =
+    StateNotifierProvider<ThemeNotifier, ThemeState>((ref) {
+  return ThemeNotifier();
+});
+
+/// Provides the light [ThemeData] based on the selected palette.
+final lightThemeProvider = Provider<ThemeData>((ref) {
+  final state = ref.watch(themeNotifierProvider);
+  final seed = paletteSeeds[state.palette] ?? AppColors.defaultSeed;
+  return AppTheme.lightTheme(seed);
+});
+
+/// Provides the dark [ThemeData] based on the selected palette.
+final darkThemeProvider = Provider<ThemeData>((ref) {
+  final state = ref.watch(themeNotifierProvider);
+  final seed = paletteSeeds[state.palette] ?? AppColors.defaultSeed;
+  return AppTheme.darkTheme(seed);
+});
+
+/// Exposes the current [ThemeMode].
+final themeModeProvider = Provider<ThemeMode>((ref) {
+  return ref.watch(themeNotifierProvider).mode;
+});

--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -8,4 +8,7 @@ class AppColors {
   static const Color secondary = Color(0xFFFF6600);
   static const Color background = Color(0xFFF5F5F5);
   static const Color error = Color(0xFFD32F2F);
+
+  /// Default seed color used when no custom palette is selected.
+  static const Color defaultSeed = Color(0xFF0066FF);
 }

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -5,12 +5,22 @@ import 'app_text_styles.dart';
 
 /// Application theme built with Material 3 color schemes.
 class AppTheme {
-  static ThemeData get lightTheme => _buildTheme(Brightness.light);
-  static ThemeData get darkTheme => _buildTheme(Brightness.dark);
+  static ThemeData lightTheme(Color seedColor) =>
+      _buildTheme(seedColor: seedColor, brightness: Brightness.light);
 
-  static ThemeData _buildTheme(Brightness brightness) {
+  static ThemeData darkTheme(Color seedColor) =>
+      _buildTheme(seedColor: seedColor, brightness: Brightness.dark);
+
+  static ThemeData fromSeed(Color seedColor,
+          {Brightness brightness = Brightness.light}) =>
+      _buildTheme(seedColor: seedColor, brightness: brightness);
+
+  static ThemeData _buildTheme({
+    required Color seedColor,
+    required Brightness brightness,
+  }) {
     final colorScheme = ColorScheme.fromSeed(
-      seedColor: AppColors.seed,
+      seedColor: seedColor,
       brightness: brightness,
     );
 

--- a/lib/theme/sample_palettes.dart
+++ b/lib/theme/sample_palettes.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+/// Predefined color palettes that can be selected at runtime.
+enum AppPalette { blue, green, orange }
+
+/// Mapping of palettes to their seed colors.
+const Map<AppPalette, Color> paletteSeeds = {
+  AppPalette.blue: Colors.blue,
+  AppPalette.green: Colors.green,
+  AppPalette.orange: Colors.deepOrange,
+};


### PR DESCRIPTION
## Summary
- allow multiple sample color palettes
- build `AppTheme` from an arbitrary seed color
- provide `ThemeNotifier` using Riverpod for palette & theme mode selection
- wire runtime theme switching into `MyApp` & Settings screen

## Testing
- `dart format`
- `dart test --coverage` *(fails: storage.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68628fc8989c832494e9ec5cccecfebe