### PR TITLE
Refactor booking submission helper

### DIFF
--- a/lib/features/booking/booking_helper.dart
+++ b/lib/features/booking/booking_helper.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../models/booking.dart';
+import '../providers/selection_provider.dart';
+import '../services/booking_service.dart';
+import '../../providers/auth_provider.dart';
+
+class BookingHelper {
+  final WidgetRef ref;
+  BookingHelper(this.ref);
+
+  String get _userId {
+    final user = ref.read(authProvider).currentUser;
+    final userId = user?.uid ?? '';
+    if (userId.isEmpty) throw Exception('User not logged in');
+    return userId;
+  }
+
+  Booking _buildBooking() {
+    final staffId = ref.read(staffSelectionProvider);
+    final serviceId = ref.read(serviceSelectionProvider);
+    final serviceName = ref.read(serviceNameProvider);
+    final dateTime = ref.read(selectedSlotProvider);
+    final duration = ref.read(serviceDurationProvider);
+
+    if (staffId == null ||
+        serviceId == null ||
+        dateTime == null ||
+        duration == null) {
+      throw Exception('Missing required booking information');
+    }
+
+    return Booking(
+      id: '',
+      userId: _userId,
+      staffId: staffId,
+      serviceId: serviceId,
+      serviceName: serviceName ?? 'Unknown Service',
+      dateTime: dateTime,
+      duration: duration,
+      notes: null,
+      createdAt: DateTime.now(),
+    );
+  }
+
+  Future<void> submitBooking() async {
+    final booking = _buildBooking();
+    await ref.read(bookingServiceProvider).submitBooking(booking);
+  }
+}
+

--- a/lib/features/booking/screens/booking_request_screen.dart
+++ b/lib/features/booking/screens/booking_request_screen.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../../models/booking.dart';
-import '../services/booking_service.dart';
-import '../../../providers/auth_provider.dart';
+import '../booking_helper.dart';
+import '../../../utils/snackbar_extensions.dart';
 import '../../selection/providers/selection_provider.dart';
 
 class BookingRequestScreen extends ConsumerStatefulWidget {
@@ -19,52 +18,22 @@ class _BookingRequestScreenState extends ConsumerState<BookingRequestScreen> {
   Future<void> _submitBooking() async {
     setState(() => _isSubmitting = true);
 
-    try {
-      final user = ref.read(authProvider).currentUser;
-      final userId = user?.uid ?? '';
-      if (userId.isEmpty) throw Exception('User not logged in');
-
-      final staffId = ref.read(staffSelectionProvider);
-      final serviceId = ref.read(serviceSelectionProvider);
-      final serviceName = ref.read(serviceNameProvider);
-      final dateTime = ref.read(selectedSlotProvider);
-      final duration = ref.read(serviceDurationProvider);
-
-      if (staffId == null ||
-          serviceId == null ||
-          dateTime == null ||
-          duration == null) {
-        throw Exception('Missing required booking information');
-      }
-
-      final booking = Booking(
-        id: '', // Will be set by Firestore
-        userId: userId,
-        staffId: staffId,
-        serviceId: serviceId,
-        serviceName: serviceName ?? 'Unknown Service',
-        dateTime: dateTime,
-        duration: duration,
-        notes: null,
-        createdAt: DateTime.now(),
-      );
-
-      await ref.read(bookingServiceProvider).submitBooking(booking);
-
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Booking confirmed')),
-      );
-      Navigator.pop(context);
-    } catch (e, st) {
-      debugPrint('Error during booking: $e\n$st');
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Failed to confirm booking')),
-      );
-    } finally {
-      if (mounted) setState(() => _isSubmitting = false);
-    }
+    BookingHelper(ref)
+        .submitBooking()
+        .then((_) {
+          if (!mounted) return;
+          context.showSnackBar('Booking confirmed');
+          Navigator.pop(context);
+        })
+        .catchError((e, st) {
+          debugPrint('Error during booking: $e\n$st');
+          if (!mounted) return;
+          context.showSnackBar('Failed to confirm booking',
+              backgroundColor: Colors.red);
+        })
+        .whenComplete(() {
+          if (mounted) setState(() => _isSubmitting = false);
+        });
   }
 
   @override

--- a/lib/utils/snackbar_extensions.dart
+++ b/lib/utils/snackbar_extensions.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+extension SnackBarExtensions on BuildContext {
+  void showSnackBar(String message, {Color? backgroundColor}) {
+    ScaffoldMessenger.of(this).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: backgroundColor,
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- centralize booking submission into new `BookingHelper`
- add `showSnackBar` BuildContext extension
- update booking screens to use the helper

## Testing
- `dart analyze` *(fails: integration_test dependencies)*
- `dart test --coverage` *(failed to run due to Dart SDK version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6862912f14ec832496a2a4c82415697a