### PR TITLE
Add reusable Flutter animation widgets

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -11,6 +11,7 @@ import '../features/studio/ui/staff_screen.dart';
 import '../features/studio/ui/providers_screen.dart';
 import '../features/booking/screens/chat_booking_screen.dart';
 import '../features/booking/booking_request_screen.dart';
+import '../widgets/animations/fade_slide_page_route.dart';
 import '../features/dashboard/dashboard_screen.dart';
 import '../features/personal_app/ui/profile_screen.dart';
 import '../features/personal_app/ui/edit_profile_screen.dart';
@@ -96,9 +97,10 @@ class AppRouter {
           settings: settings,
         );
       case '/booking/request':
-        return MaterialPageRoute(
-          builder: (_) => const BookingRequestScreen(),
+        return FadeSlidePageRoute(
+          page: const BookingRequestScreen(),
           settings: settings,
+          direction: AxisDirection.up,
         );
       case '/dashboard':
         return MaterialPageRoute(

--- a/lib/features/booking/screens/booking_screen.dart
+++ b/lib/features/booking/screens/booking_screen.dart
@@ -7,6 +7,8 @@ import '../../../models/booking.dart';
 import '../services/booking_service.dart';
 import '../../../providers/auth_provider.dart';
 import '../../selection/providers/selection_provider.dart';
+import '../../../widgets/animations/tap_scale_feedback.dart';
+import '../../../widgets/animations/fade_slide_in.dart';
 
 class BookingScreen extends ConsumerStatefulWidget {
   const BookingScreen({super.key});
@@ -76,10 +78,9 @@ class _BookingScreenState extends ConsumerState<BookingScreen> {
     final duration = ref.read(serviceDurationProvider);
     if (staffId == null || dateTime == null || duration == null) return;
 
-    final summary =
-        'You are about to book $serviceName with $staffId on ' +
-            DateFormat.yMMMEd().add_jm().format(dateTime) +
-            ' for ${duration.inMinutes} minutes.';
+    final summary = 'You are about to book $serviceName with $staffId on ' +
+        DateFormat.yMMMEd().add_jm().format(dateTime) +
+        ' for ${duration.inMinutes} minutes.';
 
     BottomSheetManager.show(
       context: context,
@@ -108,11 +109,13 @@ class _BookingScreenState extends ConsumerState<BookingScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            // Chat Booking Button
-            ElevatedButton.icon(
-              onPressed: () => Navigator.pushNamed(context, '/chat-booking'),
-              icon: const Icon(Icons.chat_bubble_outline),
-              label: const Text('Book via Chat'),
+            // Chat Booking Button with tap feedback
+            TapScaleFeedback(
+              child: ElevatedButton.icon(
+                onPressed: () => Navigator.pushNamed(context, '/chat-booking'),
+                icon: const Icon(Icons.chat_bubble_outline),
+                label: const Text('Book via Chat'),
+              ),
             ),
             const SizedBox(height: 16),
             Card(
@@ -134,16 +137,18 @@ class _BookingScreenState extends ConsumerState<BookingScreen> {
               ),
             ),
             const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: (staffId != null &&
-                      serviceId != null &&
-                      dateTime != null &&
-                      duration != null)
-                  ? (_isSubmitting ? null : _showConfirmationSheet)
-                  : null,
-              child: _isSubmitting
-                  ? const CircularProgressIndicator()
-                  : const Text('Submit Booking'),
+            TapScaleFeedback(
+              child: ElevatedButton(
+                onPressed: (staffId != null &&
+                        serviceId != null &&
+                        dateTime != null &&
+                        duration != null)
+                    ? (_isSubmitting ? null : _showConfirmationSheet)
+                    : null,
+                child: _isSubmitting
+                    ? const CircularProgressIndicator()
+                    : const Text('Submit Booking'),
+              ),
             ),
             const SizedBox(height: 24),
             const Expanded(
@@ -186,16 +191,19 @@ class BookingListView extends ConsumerWidget {
           itemCount: bookingsList.length,
           itemBuilder: (context, index) {
             final booking = bookingsList[index];
-            return Card(
-              margin: const EdgeInsets.symmetric(vertical: 8),
-              child: ListTile(
-                title: Text('\uD83D\uDCC5 ${booking.dateTime.toLocal()}'),
-                subtitle: Text(booking.notes ?? ''),
-                trailing: IconButton(
-                  icon: const Icon(Icons.delete),
-                  onPressed: () => ref
-                      .read(bookingServiceProvider)
-                      .cancelBooking(booking.id),
+            return FadeSlideIn(
+              delay: Duration(milliseconds: 50 * index),
+              child: Card(
+                margin: const EdgeInsets.symmetric(vertical: 8),
+                child: ListTile(
+                  title: Text('\uD83D\uDCC5 ${booking.dateTime.toLocal()}'),
+                  subtitle: Text(booking.notes ?? ''),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.delete),
+                    onPressed: () => ref
+                        .read(bookingServiceProvider)
+                        .cancelBooking(booking.id),
+                  ),
                 ),
               ),
             );

--- a/lib/widgets/animations/fade_slide_in.dart
+++ b/lib/widgets/animations/fade_slide_in.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+
+/// Animates its child fading in while sliding from a given [direction].
+class FadeSlideIn extends StatefulWidget {
+  const FadeSlideIn({
+    super.key,
+    required this.child,
+    this.direction = AxisDirection.down,
+    this.duration = const Duration(milliseconds: 400),
+    this.delay = Duration.zero,
+  });
+
+  final Widget child;
+  final AxisDirection direction;
+  final Duration duration;
+  final Duration delay;
+
+  @override
+  State<FadeSlideIn> createState() => _FadeSlideInState();
+}
+
+class _FadeSlideInState extends State<FadeSlideIn>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<Offset> _offset;
+  late final Animation<double> _opacity;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: widget.duration,
+    );
+    _offset = Tween<Offset>(
+      begin: _offsetForDirection(widget.direction),
+      end: Offset.zero,
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
+    _opacity = CurvedAnimation(parent: _controller, curve: Curves.easeOut);
+    _startAnimation();
+  }
+
+  Future<void> _startAnimation() async {
+    if (widget.delay > Duration.zero) {
+      await Future<void>.delayed(widget.delay);
+    }
+    if (mounted) {
+      _controller.forward();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        return Opacity(
+          opacity: _opacity.value,
+          child: SlideTransition(position: _offset, child: child!),
+        );
+      },
+      child: widget.child,
+    );
+  }
+
+  static Offset _offsetForDirection(AxisDirection direction) {
+    switch (direction) {
+      case AxisDirection.up:
+        return const Offset(0, 0.2);
+      case AxisDirection.down:
+        return const Offset(0, -0.2);
+      case AxisDirection.left:
+        return const Offset(0.2, 0);
+      case AxisDirection.right:
+        return const Offset(-0.2, 0);
+    }
+  }
+}

--- a/lib/widgets/animations/fade_slide_page_route.dart
+++ b/lib/widgets/animations/fade_slide_page_route.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+/// A [PageRoute] that fades and slides the new page in from a direction.
+class FadeSlidePageRoute<T> extends PageRouteBuilder<T> {
+  FadeSlidePageRoute({
+    required Widget page,
+    this.direction = AxisDirection.right,
+    super.settings,
+    Duration duration = const Duration(milliseconds: 300),
+  }) : super(
+          pageBuilder: (_, __, ___) => page,
+          transitionDuration: duration,
+          transitionsBuilder: (context, animation, secondaryAnimation, child) {
+            final offsetAnimation = Tween<Offset>(
+              begin: _offsetForDirection(direction),
+              end: Offset.zero,
+            ).animate(
+                CurvedAnimation(parent: animation, curve: Curves.easeOut));
+
+            return SlideTransition(
+              position: offsetAnimation,
+              child: FadeTransition(
+                opacity: animation,
+                child: child,
+              ),
+            );
+          },
+        );
+
+  final AxisDirection direction;
+
+  static Offset _offsetForDirection(AxisDirection direction) {
+    switch (direction) {
+      case AxisDirection.up:
+        return const Offset(0, 0.1);
+      case AxisDirection.down:
+        return const Offset(0, -0.1);
+      case AxisDirection.left:
+        return const Offset(0.1, 0);
+      case AxisDirection.right:
+        return const Offset(-0.1, 0);
+    }
+  }
+}

--- a/lib/widgets/animations/tap_scale_feedback.dart
+++ b/lib/widgets/animations/tap_scale_feedback.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+/// Provides a simple tap feedback by scaling the child.
+/// Can wrap any widget that needs a pressed state animation.
+class TapScaleFeedback extends StatefulWidget {
+  const TapScaleFeedback({
+    super.key,
+    required this.child,
+    this.onTap,
+    this.scale = 0.95,
+    this.duration = const Duration(milliseconds: 100),
+  });
+
+  final Widget child;
+  final VoidCallback? onTap;
+  final double scale;
+  final Duration duration;
+
+  @override
+  State<TapScaleFeedback> createState() => _TapScaleFeedbackState();
+}
+
+class _TapScaleFeedbackState extends State<TapScaleFeedback> {
+  bool _pressed = false;
+
+  void _handleDown(PointerDownEvent event) {
+    setState(() => _pressed = true);
+  }
+
+  void _handleUp(PointerUpEvent event) {
+    setState(() => _pressed = false);
+  }
+
+  void _handleCancel(PointerCancelEvent event) {
+    setState(() => _pressed = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerDown: _handleDown,
+      onPointerUp: _handleUp,
+      onPointerCancel: _handleCancel,
+      child: AnimatedScale(
+        scale: _pressed ? widget.scale : 1.0,
+        duration: widget.duration,
+        curve: Curves.easeOut,
+        child: GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTap: widget.onTap,
+          child: widget.child,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `FadeSlidePageRoute` for animated page transitions
- add `TapScaleFeedback` and `FadeSlideIn` animation widgets
- integrate tap feedback buttons and list entry animation in booking screen
- use slide+fade transition when navigating to BookingRequest screen

## Testing
- `dart pub get` *(fails: storage.googleapis.com blocked)*
- `dart test --coverage` *(fails: storage.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6862932c783c8324a5e938dc6976a81a