### PR TITLE
Add deep linking and referral docs

### DIFF
--- a/docs/deep_linking.md
+++ b/docs/deep_linking.md
@@ -1,0 +1,67 @@
+# Deep Linking Module
+
+## Architecture Overview
+
+The deep linking system centers around `CustomDeepLinkService` and works with
+`WhatsAppShareService` to create and handle links. The service listens to
+incoming URI events via `uni_links` and can navigate the user to the correct
+screen. Links are generated with custom parameters so that analytics are stored
+when a link is shared or opened.
+
+```mermaid
+flowchart TD
+    A[WhatsAppShareService] -- create link --> B(CustomDeepLinkService)
+    B --> C[Share URL]
+    C -- open link --> D[CustomDeepLinkService]
+    D --> E[App Router]
+```
+
+1. `WhatsAppShareService` requests a meeting link from
+   `CustomDeepLinkService`.
+2. The link is included in a WhatsApp message and logged for analytics.
+3. When the link is opened, `CustomDeepLinkService` parses the URI and (when the
+   code is enabled) navigates via the provided `NavigatorState`.
+
+## Key Classes and Responsibilities
+
+### `CustomDeepLinkService`
+- **initialize()** – sets up listeners for initial and ongoing URI events.
+- **setNavigatorKey()** – supplies the navigator used for routing.
+- **createMeetingLink()** – builds a URL with meeting, creator and optional
+  group or context identifiers.
+- **createShortLink()** – stub for connecting a URL shortener.
+- **dispose()** – cleans up stream subscriptions.
+
+### `WhatsAppShareService`
+- **generateSmartShareLink()** – obtains a meeting link and stores share
+  analytics.
+- **shareToWhatsApp()** – launches WhatsApp or falls back to general sharing.
+- **handleDeepLink()** – processes opened links and logs analytics.
+- **logShareAnalytics()** – records share events in Firestore.
+
+The data models used for analytics (`SmartShareLink`, `GroupRecognition` and
+`ShareAnalytics`) live in `lib/models/smart_share_link.dart`.
+
+## Extending or Debugging
+
+Generate a link and share it:
+
+```dart
+final deepLinkService = CustomDeepLinkService();
+final shareService = WhatsAppShareService(deepLinkService: deepLinkService);
+
+final url = await deepLinkService.createMeetingLink(
+  meetingId: '123',
+  creatorId: 'abc',
+);
+await shareService.shareToWhatsApp(
+  meetingId: '123',
+  creatorId: 'abc',
+  customMessage: 'Join me!',
+);
+```
+
+To debug incoming links, temporarily uncomment the logic in
+`_handleDeepLink` inside `CustomDeepLinkService` and watch the console for the
+"Handling deep link" output.
+

--- a/docs/referral.md
+++ b/docs/referral.md
@@ -1,0 +1,52 @@
+# Referral Module
+
+## Architecture Overview
+
+Referral codes allow users to invite others and gain rewards. Codes are stored in
+Firestore and surfaced through a Riverpod provider so widgets can easily display
+or copy them. The flow is:
+
+```mermaid
+flowchart TD
+    A[ReferralScreen] --watch--> B[referralCodeProvider]
+    B --> C[ReferralService]
+    C --firestore--> D[referrals collection]
+```
+
+1. `ReferralScreen` watches `referralCodeProvider`.
+2. The provider uses `ReferralService` to fetch or generate a code for the
+   current user.
+3. `ReferralService` saves codes to the Firestore `referrals` collection and
+   ensures uniqueness.
+
+## Key Classes and Responsibilities
+
+### `ReferralService`
+- **generateReferralCode()** – creates a unique 8-character code for a given
+  user. Existing codes are reused if they already exist.
+- **generateReferralCodeForCurrentUser()** – helper that uses the current
+  Firebase user.
+
+### Providers
+- **referralServiceProvider** – exposes a `ReferralService` instance.
+- **referralCodeProvider** – async provider that returns the user’s code,
+  throwing if the user is not logged in.
+
+### UI
+- **ReferralScreen** – simple page that shows the code and lets the user copy it
+  to the clipboard.
+
+## Extending or Debugging
+
+Generate a referral code manually:
+
+```dart
+final service = ReferralService();
+final code = await service.generateReferralCode('USER_ID');
+print('New code: $code');
+```
+
+If codes appear duplicated, ensure the `referrals` collection has a unique index
+on the `code` field and step through `generateReferralCode` with a debugger to
+inspect the Firestore queries.
+


### PR DESCRIPTION
## Summary
- document custom deep linking service and WhatsApp share integration
- add overview of referral service and provider flow

## Testing
- `flutter pub get --offline`
- `dart test --coverage` *(fails: Dart SDK 3.3.0 < required 3.4.0)*

------
https://chatgpt.com/codex/tasks/task_e_68629335dcac8324a8cae33b0367ac66