### PR TITLE
Implement family support and personal scheduler

### DIFF
--- a/lib/auth_wrapper.dart
+++ b/lib/auth_wrapper.dart
@@ -11,6 +11,10 @@ import 'features/personal_app/onboarding_screen.dart';
 import 'features/personal_app/home_feed_screen.dart';
 // ignore: unused_import
 import 'features/scheduler/scheduler_screen.dart';
+// ignore: unused_import
+import 'features/family_support/screens/family_support_screen.dart';
+// ignore: unused_import
+import 'features/personal_scheduler/screens/personal_scheduler_screen.dart';
 
 class AuthWrapper extends StatelessWidget {
   const AuthWrapper({super.key});

--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -25,6 +25,8 @@ import '../features/child/ui/parental_control_screen.dart';
 import '../features/family/screens/permissions_screen.dart';
 import '../features/family/ui/parental_consent_prompt.dart';
 import '../features/family/ui/parental_settings_screen.dart';
+import '../features/family_support/screens/family_support_screen.dart';
+import '../features/personal_scheduler/screens/personal_scheduler_screen.dart';
 import '../features/invite/invite_detail_screen.dart';
 import '../features/booking/booking_confirm_screen.dart';
 import '../features/admin/admin_broadcast_screen.dart';
@@ -169,6 +171,16 @@ class AppRouter {
         final familyLink = settings.arguments as dynamic;
         return MaterialPageRoute(
           builder: (_) => PermissionsScreen(familyLink: familyLink),
+          settings: settings,
+        );
+      case '/family/support':
+        return MaterialPageRoute(
+          builder: (_) => const FamilySupportScreen(),
+          settings: settings,
+        );
+      case '/personal/scheduler':
+        return MaterialPageRoute(
+          builder: (_) => const PersonalSchedulerScreen(),
           settings: settings,
         );
       case '/admin/broadcast':

--- a/lib/features/family_support/screens/family_support_screen.dart
+++ b/lib/features/family_support/screens/family_support_screen.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../providers/family_support_provider.dart';
+
+class FamilySupportScreen extends ConsumerStatefulWidget {
+  const FamilySupportScreen({super.key});
+
+  @override
+  ConsumerState<FamilySupportScreen> createState() =>
+      _FamilySupportScreenState();
+}
+
+class _FamilySupportScreenState extends ConsumerState<FamilySupportScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _subjectController = TextEditingController();
+  final _messageController = TextEditingController();
+  bool _submitting = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final ticketsAsync = ref.watch(supportTicketsProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Family Support')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ListView(
+          children: [
+            Form(
+              key: _formKey,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  TextFormField(
+                    controller: _subjectController,
+                    decoration: const InputDecoration(labelText: 'Subject'),
+                    validator: (v) =>
+                        v == null || v.isEmpty ? 'Required' : null,
+                  ),
+                  const SizedBox(height: 8),
+                  TextFormField(
+                    controller: _messageController,
+                    decoration: const InputDecoration(labelText: 'Message'),
+                    maxLines: 3,
+                    validator: (v) =>
+                        v == null || v.isEmpty ? 'Required' : null,
+                  ),
+                  const SizedBox(height: 8),
+                  ElevatedButton(
+                    onPressed: _submitting ? null : _submit,
+                    child: _submitting
+                        ? const CircularProgressIndicator()
+                        : const Text('Submit'),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 24),
+            const Text('Past Tickets',
+                style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            ticketsAsync.when(
+              data: (tickets) {
+                if (tickets.isEmpty) {
+                  return const Text('No tickets yet');
+                }
+                return Column(
+                  children: tickets
+                      .map(
+                        (t) => Card(
+                          child: ListTile(
+                            title: Text(t.subject),
+                            subtitle: Text(t.message),
+                            trailing: Text(t.status),
+                          ),
+                        ),
+                      )
+                      .toList(),
+                );
+              },
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (e, _) => Text('Error: $e'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() => _submitting = true);
+    try {
+      await ref
+          .read(familySupportServiceProvider)
+          .submitTicket(_subjectController.text, _messageController.text);
+      _subjectController.clear();
+      _messageController.clear();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Support ticket submitted')),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Error: $e')));
+    } finally {
+      if (mounted) setState(() => _submitting = false);
+    }
+  }
+}

--- a/lib/features/personal_scheduler/screens/personal_scheduler_screen.dart
+++ b/lib/features/personal_scheduler/screens/personal_scheduler_screen.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../models/personal_appointment.dart';
+import '../../../providers/personal_scheduler_provider.dart';
+import '../../../services/personal_scheduler_service.dart';
+
+class PersonalSchedulerScreen extends ConsumerStatefulWidget {
+  const PersonalSchedulerScreen({super.key});
+
+  @override
+  ConsumerState<PersonalSchedulerScreen> createState() =>
+      _PersonalSchedulerScreenState();
+}
+
+class _PersonalSchedulerScreenState
+    extends ConsumerState<PersonalSchedulerScreen> {
+  DateTime _focusedDay = DateTime.now();
+
+  @override
+  Widget build(BuildContext context) {
+    final apptsAsync = ref.watch(personalAppointmentsProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('My Schedule')),
+      body: Column(
+        children: [
+          CalendarDatePicker(
+            initialDate: _focusedDay,
+            firstDate: DateTime(2000),
+            lastDate: DateTime(2100),
+            onDateChanged: (d) => setState(() => _focusedDay = d),
+          ),
+          Expanded(
+            child: apptsAsync.when(
+              data: (appts) {
+                final dayAppts = appts
+                    .where((a) =>
+                        a.startTime.year == _focusedDay.year &&
+                        a.startTime.month == _focusedDay.month &&
+                        a.startTime.day == _focusedDay.day)
+                    .toList();
+                if (dayAppts.isEmpty) {
+                  return const Center(child: Text('No appointments'));
+                }
+                return ListView(
+                  children: dayAppts
+                      .map(
+                        (a) => ListTile(
+                          title: Text(a.title),
+                          subtitle: Text(
+                              '${a.startTime.hour.toString().padLeft(2, '0')}:${a.startTime.minute.toString().padLeft(2, '0')} - '
+                              '${a.endTime.hour.toString().padLeft(2, '0')}:${a.endTime.minute.toString().padLeft(2, '0')}'),
+                          trailing: IconButton(
+                            icon: const Icon(Icons.delete),
+                            onPressed: () => _delete(a.id),
+                          ),
+                          onTap: () => _edit(a),
+                        ),
+                      )
+                      .toList(),
+                );
+              },
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (e, _) => Center(child: Text('Error: $e')),
+            ),
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _add,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  Future<void> _add() async {
+    final newAppt = await _showEditDialog();
+    if (newAppt != null) {
+      await ref.read(personalSchedulerServiceProvider).addAppointment(newAppt);
+    }
+  }
+
+  Future<void> _edit(PersonalAppointment appt) async {
+    final updated = await _showEditDialog(existing: appt);
+    if (updated != null) {
+      await ref
+          .read(personalSchedulerServiceProvider)
+          .updateAppointment(updated);
+    }
+  }
+
+  Future<void> _delete(String id) async {
+    await ref.read(personalSchedulerServiceProvider).deleteAppointment(id);
+  }
+
+  Future<PersonalAppointment?> _showEditDialog(
+      {PersonalAppointment? existing}) {
+    final titleCtrl = TextEditingController(text: existing?.title);
+    final descCtrl = TextEditingController(text: existing?.description);
+    DateTime start = existing?.startTime ?? _focusedDay;
+    DateTime end =
+        existing?.endTime ?? _focusedDay.add(const Duration(hours: 1));
+
+    return showDialog<PersonalAppointment>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title:
+              Text(existing == null ? 'New Appointment' : 'Edit Appointment'),
+          content: SingleChildScrollView(
+            child: Column(
+              children: [
+                TextField(
+                  controller: titleCtrl,
+                  decoration: const InputDecoration(labelText: 'Title'),
+                ),
+                TextField(
+                  controller: descCtrl,
+                  decoration: const InputDecoration(labelText: 'Description'),
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Expanded(
+                      child: TextButton(
+                        onPressed: () async {
+                          final d = await showDatePicker(
+                            context: context,
+                            initialDate: start,
+                            firstDate: DateTime(2000),
+                            lastDate: DateTime(2100),
+                          );
+                          if (d != null) {
+                            setState(() {
+                              start = DateTime(d.year, d.month, d.day,
+                                  start.hour, start.minute);
+                              end = start.add(const Duration(hours: 1));
+                            });
+                          }
+                        },
+                        child: Text(
+                            'Date: ${start.year}-${start.month}-${start.day}'),
+                      ),
+                    ),
+                    Expanded(
+                      child: TextButton(
+                        onPressed: () async {
+                          final t = await showTimePicker(
+                            context: context,
+                            initialTime: TimeOfDay.fromDateTime(start),
+                          );
+                          if (t != null) {
+                            setState(() {
+                              start = DateTime(start.year, start.month,
+                                  start.day, t.hour, t.minute);
+                              end = start.add(const Duration(hours: 1));
+                            });
+                          }
+                        },
+                        child: Text(
+                            'Start: ${start.hour.toString().padLeft(2, '0')}:${start.minute.toString().padLeft(2, '0')}'),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () {
+                final id = existing?.id ?? const Uuid().v4();
+                final userId = existing?.userId ??
+                    ref
+                        .read(personalSchedulerServiceProvider)
+                        ._auth
+                        .currentUser!
+                        .uid;
+                final appt = PersonalAppointment(
+                  id: id,
+                  userId: userId,
+                  title: titleCtrl.text,
+                  description: descCtrl.text,
+                  startTime: start,
+                  endTime: end,
+                );
+                Navigator.pop(context, appt);
+              },
+              child: const Text('Save'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/models/personal_appointment.dart
+++ b/lib/models/personal_appointment.dart
@@ -1,0 +1,41 @@
+import '../utils/datetime_converter.dart';
+
+class PersonalAppointment {
+  final String id;
+  final String userId;
+  final String title;
+  final String description;
+  @DateTimeConverter()
+  final DateTime startTime;
+  @DateTimeConverter()
+  final DateTime endTime;
+
+  PersonalAppointment({
+    required this.id,
+    required this.userId,
+    required this.title,
+    required this.description,
+    required this.startTime,
+    required this.endTime,
+  });
+
+  factory PersonalAppointment.fromJson(Map<String, dynamic> json) {
+    return PersonalAppointment(
+      id: json['id'] as String,
+      userId: json['userId'] as String,
+      title: json['title'] as String,
+      description: json['description'] as String,
+      startTime: DateTime.parse(json['startTime'] as String),
+      endTime: DateTime.parse(json['endTime'] as String),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'userId': userId,
+        'title': title,
+        'description': description,
+        'startTime': startTime.toIso8601String(),
+        'endTime': endTime.toIso8601String(),
+      };
+}

--- a/lib/models/support_ticket.dart
+++ b/lib/models/support_ticket.dart
@@ -1,0 +1,40 @@
+import '../utils/datetime_converter.dart';
+
+class SupportTicket {
+  final String id;
+  final String userId;
+  final String subject;
+  final String message;
+  @DateTimeConverter()
+  final DateTime createdAt;
+  final String status;
+
+  SupportTicket({
+    required this.id,
+    required this.userId,
+    required this.subject,
+    required this.message,
+    required this.createdAt,
+    this.status = 'open',
+  });
+
+  factory SupportTicket.fromJson(Map<String, dynamic> json) {
+    return SupportTicket(
+      id: json['id'] as String,
+      userId: json['userId'] as String,
+      subject: json['subject'] as String,
+      message: json['message'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      status: json['status'] as String? ?? 'open',
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'userId': userId,
+        'subject': subject,
+        'message': message,
+        'createdAt': createdAt.toIso8601String(),
+        'status': status,
+      };
+}

--- a/lib/providers/family_support_provider.dart
+++ b/lib/providers/family_support_provider.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/support_ticket.dart';
+import '../services/family_support_service.dart';
+
+final familySupportServiceProvider =
+    Provider<FamilySupportService>((ref) => FamilySupportService());
+
+final supportTicketsProvider = StreamProvider<List<SupportTicket>>((ref) {
+  return ref.watch(familySupportServiceProvider).watchTickets();
+});

--- a/lib/providers/personal_scheduler_provider.dart
+++ b/lib/providers/personal_scheduler_provider.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/personal_appointment.dart';
+import '../services/personal_scheduler_service.dart';
+
+final personalSchedulerServiceProvider =
+    Provider<PersonalSchedulerService>((ref) => PersonalSchedulerService());
+
+final personalAppointmentsProvider =
+    StreamProvider<List<PersonalAppointment>>((ref) {
+  return ref.watch(personalSchedulerServiceProvider).watchAppointments();
+});

--- a/lib/services/family_support_service.dart
+++ b/lib/services/family_support_service.dart
@@ -1,0 +1,43 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../models/support_ticket.dart';
+
+class FamilySupportService {
+  final FirebaseFirestore _firestore;
+  final FirebaseAuth _auth;
+
+  FamilySupportService({FirebaseFirestore? firestore, FirebaseAuth? auth})
+      : _firestore = firestore ?? FirebaseFirestore.instance,
+        _auth = auth ?? FirebaseAuth.instance;
+
+  CollectionReference<SupportTicket> get _collection =>
+      _firestore.collection('supportTickets').withConverter<SupportTicket>(
+            fromFirestore: (snap, _) => SupportTicket.fromJson(snap.data()!),
+            toFirestore: (ticket, _) => ticket.toJson(),
+          );
+
+  Future<void> submitTicket(String subject, String message) async {
+    final uid = _auth.currentUser?.uid;
+    if (uid == null) throw Exception('Not logged in');
+    final doc = _collection.doc();
+    final ticket = SupportTicket(
+      id: doc.id,
+      userId: uid,
+      subject: subject,
+      message: message,
+      createdAt: DateTime.now(),
+    );
+    await doc.set(ticket);
+  }
+
+  Stream<List<SupportTicket>> watchTickets() {
+    final uid = _auth.currentUser?.uid;
+    if (uid == null) return const Stream.empty();
+    return _collection
+        .where('userId', isEqualTo: uid)
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map((snap) => snap.docs.map((d) => d.data()).toList());
+  }
+}

--- a/lib/services/personal_scheduler_service.dart
+++ b/lib/services/personal_scheduler_service.dart
@@ -1,0 +1,42 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../models/personal_appointment.dart';
+
+class PersonalSchedulerService {
+  final FirebaseFirestore _firestore;
+  final FirebaseAuth _auth;
+
+  PersonalSchedulerService({FirebaseFirestore? firestore, FirebaseAuth? auth})
+      : _firestore = firestore ?? FirebaseFirestore.instance,
+        _auth = auth ?? FirebaseAuth.instance;
+
+  CollectionReference<PersonalAppointment> get _collection => _firestore
+      .collection('personalAppointments')
+      .withConverter<PersonalAppointment>(
+        fromFirestore: (snap, _) => PersonalAppointment.fromJson(snap.data()!),
+        toFirestore: (appt, _) => appt.toJson(),
+      );
+
+  Stream<List<PersonalAppointment>> watchAppointments() {
+    final uid = _auth.currentUser?.uid;
+    if (uid == null) return const Stream.empty();
+    return _collection
+        .where('userId', isEqualTo: uid)
+        .orderBy('startTime')
+        .snapshots()
+        .map((snap) => snap.docs.map((d) => d.data()).toList());
+  }
+
+  Future<void> addAppointment(PersonalAppointment appt) async {
+    await _collection.doc(appt.id).set(appt);
+  }
+
+  Future<void> updateAppointment(PersonalAppointment appt) async {
+    await _collection.doc(appt.id).set(appt);
+  }
+
+  Future<void> deleteAppointment(String id) async {
+    await _collection.doc(id).delete();
+  }
+}

--- a/test/models/personal_appointment_test.dart
+++ b/test/models/personal_appointment_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/models/personal_appointment.dart';
+import '../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  group('PersonalAppointment', () {
+    test('toJson/fromJson round trip', () {
+      final appt = PersonalAppointment(
+        id: 'a1',
+        userId: 'u1',
+        title: 'Meeting',
+        description: 'Discuss project',
+        startTime: DateTime(2024, 1, 1, 10, 0),
+        endTime: DateTime(2024, 1, 1, 11, 0),
+      );
+      final json = appt.toJson();
+      final copy = PersonalAppointment.fromJson(json);
+      expect(copy.id, appt.id);
+      expect(copy.userId, appt.userId);
+      expect(copy.title, appt.title);
+      expect(copy.description, appt.description);
+      expect(copy.startTime, appt.startTime);
+      expect(copy.endTime, appt.endTime);
+    });
+  });
+}

--- a/test/models/support_ticket_test.dart
+++ b/test/models/support_ticket_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appoint/models/support_ticket.dart';
+import '../fake_firebase_setup.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeTestFirebase();
+
+  group('SupportTicket', () {
+    test('toJson/fromJson round trip', () {
+      final ticket = SupportTicket(
+        id: '1',
+        userId: 'u1',
+        subject: 'Help',
+        message: 'Need assistance',
+        createdAt: DateTime(2024, 1, 1),
+      );
+      final json = ticket.toJson();
+      final copy = SupportTicket.fromJson(json);
+      expect(copy.id, ticket.id);
+      expect(copy.userId, ticket.userId);
+      expect(copy.subject, ticket.subject);
+      expect(copy.message, ticket.message);
+      expect(copy.createdAt, ticket.createdAt);
+      expect(copy.status, ticket.status);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `SupportTicket` and `PersonalAppointment` models
- create services and providers for family support and personal scheduler modules
- implement `FamilySupportScreen` for submitting requests and listing past tickets
- implement `PersonalSchedulerScreen` with basic calendar and CRUD controls
- connect routes and auth wrapper to new screens
- add basic model tests

## Testing
- `dart format lib/models/support_ticket.dart lib/models/personal_appointment.dart lib/services/family_support_service.dart lib/services/personal_scheduler_service.dart lib/providers/family_support_provider.dart lib/providers/personal_scheduler_provider.dart lib/features/family_support/screens/family_support_screen.dart lib/features/personal_scheduler/screens/personal_scheduler_screen.dart lib/auth_wrapper.dart lib/config/routes.dart`
- `dart test --coverage` *(fails: Dart SDK 3.3.0 < 3.4.0)*

------
https://chatgpt.com/codex/tasks/task_e_68629345f8b48324bf1cee0da33bd5ae