### PR TITLE
Mock Firebase services in tests

### DIFF
--- a/test/features/booking/chat_booking_test.dart
+++ b/test/features/booking/chat_booking_test.dart
@@ -4,10 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 import '../../fake_firebase_setup.dart';
 import 'package:appoint/features/booking/screens/chat_booking_screen.dart';
 import 'package:mockito/mockito.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../mocks/firebase_mocks.dart';
 import 'package:appoint/features/booking/services/booking_service.dart';
-
-class MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
 
 late BookingService bookingService;
 late MockFirebaseFirestore mockFirestore;

--- a/test/features/business/business_dashboard_screen_test.dart
+++ b/test/features/business/business_dashboard_screen_test.dart
@@ -5,9 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:appoint/features/business/screens/business_dashboard_screen.dart';
 import '../../fake_firebase_setup.dart';
 import 'package:mockito/mockito.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
-
-class MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
+import '../../mocks/firebase_mocks.dart';
 
 Future<void> main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -15,10 +13,14 @@ Future<void> main() async {
 
   testWidgets('Business Dashboard shows welcome text',
       (WidgetTester tester) async {
+    final firestore = MockFirebaseFirestore();
+
     await tester.pumpWidget(const ProviderScope(
       child: MaterialApp(home: BusinessDashboardScreen()),
     ));
 
     expect(find.text('Welcome to Business Dashboard'), findsOneWidget);
+
+    verifyZeroInteractions(firestore);
   });
 }

--- a/test/features/family/otp_flow_test.dart
+++ b/test/features/family/otp_flow_test.dart
@@ -7,8 +7,7 @@ import 'package:appoint/services/family_service.dart';
 import 'package:appoint/providers/otp_provider.dart';
 import 'package:appoint/providers/family_provider.dart';
 import 'package:mockito/mockito.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_auth/firebase_auth.dart';
+import '../../mocks/firebase_mocks.dart';
 
 Future<void> main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -85,9 +84,5 @@ class MockFamilyService extends FamilyService {
   }
 }
 
-class MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
 
-
-
-class MockFirebaseAuth extends Mock implements FirebaseAuth {}
 

--- a/test/mocks/firebase_mocks.dart
+++ b/test/mocks/firebase_mocks.dart
@@ -1,0 +1,10 @@
+import 'package:mockito/mockito.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+
+class MockFirebaseAuth extends Mock implements FirebaseAuth {}
+class MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
+class MockFirebaseFunctions extends Mock implements FirebaseFunctions {}
+class MockFirebaseStorage extends Mock implements FirebaseStorage {}


### PR DESCRIPTION
## Summary
- add reusable firebase mocks
- update booking service tests to use firestore mocks
- update OTP flow test to import firebase mocks
- update chat booking and business dashboard tests to use firebase mocks

## Testing
- `dart --version`
- `dart pub get` *(fails: The current Dart SDK version is 3.3.0)*
- `dart test --coverage` *(fails: network access to storage.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6862939159cc8324b3705f5587d861f6