### PR TITLE
Implement Content Library

### DIFF
--- a/lib/features/personal_app/ui/content_detail_screen.dart
+++ b/lib/features/personal_app/ui/content_detail_screen.dart
@@ -1,17 +1,44 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// TODO: Implement detailed content view
-class ContentDetailScreen extends StatelessWidget {
+import '../../../providers/content_provider.dart';
+
+/// Shows details for a single content item.
+class ContentDetailScreen extends ConsumerWidget {
   final String contentId;
 
   const ContentDetailScreen({super.key, required this.contentId});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final contentAsync = ref.watch(contentByIdProvider(contentId));
+
     return Scaffold(
       appBar: AppBar(title: const Text('Content Detail')),
-      body: Center(
-        child: Text('Content ID: $contentId'),
+      body: contentAsync.when(
+        data: (item) {
+          if (item == null) {
+            return const Center(child: Text('Content not found'));
+          }
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (item.imageUrl != null) Image.network(item.imageUrl!),
+                const SizedBox(height: 12),
+                Text(
+                  item.title,
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 8),
+                if (item.description != null) Text(item.description!),
+              ],
+            ),
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
       ),
     );
   }

--- a/lib/features/studio/ui/content_library_screen.dart
+++ b/lib/features/studio/ui/content_library_screen.dart
@@ -1,25 +1,75 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// TODO: Implement content list per spec §2.2
-class ContentLibraryScreen extends StatelessWidget {
+import '../../../providers/content_provider.dart';
+
+/// Displays a paginated list of content items.
+class ContentLibraryScreen extends ConsumerStatefulWidget {
   const ContentLibraryScreen({super.key});
 
   @override
+  ConsumerState<ContentLibraryScreen> createState() =>
+      _ContentLibraryScreenState();
+}
+
+class _ContentLibraryScreenState extends ConsumerState<ContentLibraryScreen> {
+  final ScrollController _controller = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(_onScroll);
+  }
+
+  void _onScroll() {
+    if (_controller.position.pixels >=
+        _controller.position.maxScrollExtent - 200) {
+      ref.read(contentPagingProvider.notifier).loadMore();
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final contentAsync = ref.watch(contentPagingProvider);
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Content Library'),
       ),
-      body: ListView(
-        children: [
-          Center(
-            child: Padding(
-              padding: EdgeInsets.all(24),
-              child: Text('No content available yet'),
-            ),
-          ),
-        ],
+      body: contentAsync.when(
+        data: (items) {
+          if (items.isEmpty) {
+            return const Center(child: Text('No content available yet'));
+          }
+          return ListView.builder(
+            controller: _controller,
+            itemCount: items.length,
+            itemBuilder: (context, index) {
+              final item = items[index];
+              return ListTile(
+                title: Text(item.title),
+                subtitle:
+                    item.description != null ? Text(item.description!) : null,
+                onTap: () {
+                  Navigator.pushNamed(
+                    context,
+                    '/content/:id',
+                    arguments: item.id,
+                  );
+                },
+              );
+            },
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
       ),
     );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
   }
 }

--- a/lib/models/content_item.dart
+++ b/lib/models/content_item.dart
@@ -1,0 +1,48 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Represents a piece of content in the library.
+class ContentItem {
+  final String id;
+  final String title;
+  final String? description;
+  final String? imageUrl;
+  final DateTime createdAt;
+
+  ContentItem({
+    required this.id,
+    required this.title,
+    this.description,
+    this.imageUrl,
+    required this.createdAt,
+  });
+
+  /// Constructs a [ContentItem] from Firestore data.
+  factory ContentItem.fromMap(String id, Map<String, dynamic> map) {
+    final ts = map['createdAt'];
+    DateTime created;
+    if (ts is Timestamp) {
+      created = ts.toDate();
+    } else if (ts is String) {
+      created = DateTime.tryParse(ts) ?? DateTime.now();
+    } else {
+      created = DateTime.now();
+    }
+    return ContentItem(
+      id: id,
+      title: map['title'] as String? ?? '',
+      description: map['description'] as String?,
+      imageUrl: map['imageUrl'] as String?,
+      createdAt: created,
+    );
+  }
+
+  /// Converts this item to a map for Firestore.
+  Map<String, dynamic> toMap() {
+    return {
+      'title': title,
+      'description': description,
+      'imageUrl': imageUrl,
+      'createdAt': Timestamp.fromDate(createdAt),
+    };
+  }
+}

--- a/lib/providers/content_provider.dart
+++ b/lib/providers/content_provider.dart
@@ -1,0 +1,56 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/content_item.dart';
+import '../services/content_service.dart';
+
+final contentServiceProvider = Provider<ContentService>((ref) {
+  return ContentService();
+});
+
+class ContentPagingNotifier
+    extends StateNotifier<AsyncValue<List<ContentItem>>> {
+  final ContentService _service;
+  final int limit;
+  final List<ContentItem> _items = [];
+  DocumentSnapshot<Map<String, dynamic>>? _lastDoc;
+  bool _hasMore = true;
+
+  ContentPagingNotifier(this._service, {this.limit = 10})
+      : super(const AsyncValue.loading()) {
+    loadMore();
+  }
+
+  bool get hasMore => _hasMore;
+
+  Future<void> loadMore() async {
+    if (!_hasMore) return;
+    try {
+      final snap =
+          await _service.fetchSnapshot(startAfter: _lastDoc, limit: limit);
+      final newItems =
+          snap.docs.map((d) => ContentItem.fromMap(d.id, d.data())).toList();
+      if (snap.docs.isNotEmpty) {
+        _lastDoc = snap.docs.last;
+      }
+      if (newItems.length < limit) {
+        _hasMore = false;
+      }
+      _items.addAll(newItems);
+      state = AsyncValue.data(List.unmodifiable(_items));
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+}
+
+final contentPagingProvider =
+    StateNotifierProvider<ContentPagingNotifier, AsyncValue<List<ContentItem>>>(
+        (ref) {
+  return ContentPagingNotifier(ref.read(contentServiceProvider));
+});
+
+final contentByIdProvider =
+    FutureProvider.family<ContentItem?, String>((ref, id) {
+  return ref.read(contentServiceProvider).fetchById(id);
+});

--- a/lib/services/content_service.dart
+++ b/lib/services/content_service.dart
@@ -1,0 +1,41 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../models/content_item.dart';
+
+/// Service for interacting with the content collection in Firestore.
+class ContentService {
+  final FirebaseFirestore _firestore;
+
+  ContentService({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  CollectionReference<Map<String, dynamic>> get _col =>
+      _firestore.collection('content_items');
+
+  /// Fetches a page of content items.
+  Future<QuerySnapshot<Map<String, dynamic>>> fetchSnapshot({
+    DocumentSnapshot<Map<String, dynamic>>? startAfter,
+    int limit = 20,
+  }) {
+    Query<Map<String, dynamic>> query =
+        _col.orderBy('createdAt', descending: true).limit(limit);
+    if (startAfter != null) {
+      query = query.startAfterDocument(startAfter);
+    }
+    return query.get();
+  }
+
+  Future<List<ContentItem>> fetchContent({
+    DocumentSnapshot<Map<String, dynamic>>? startAfter,
+    int limit = 20,
+  }) async {
+    final snap = await fetchSnapshot(startAfter: startAfter, limit: limit);
+    return snap.docs.map((d) => ContentItem.fromMap(d.id, d.data())).toList();
+  }
+
+  Future<ContentItem?> fetchById(String id) async {
+    final doc = await _col.doc(id).get();
+    if (!doc.exists) return null;
+    return ContentItem.fromMap(doc.id, doc.data()!);
+  }
+}


### PR DESCRIPTION
## Summary
- build ContentItem model for Firestore data
- create ContentService with pagination helpers
- add content providers for paginated lists and item lookup
- implement paginated ContentLibraryScreen
- implement ContentDetailScreen fetching data

## Testing
- `dart format lib/models/content_item.dart lib/services/content_service.dart lib/providers/content_provider.dart lib/features/studio/ui/content_library_screen.dart lib/features/personal_app/ui/content_detail_screen.dart`
- `flutter test --no-pub test/features/studio/content_library_screen_test.dart` *(fails: cannot run without flutter_test due to pub get)*


------
https://chatgpt.com/codex/tasks/task_e_686293a47f508324992359745c0e1174