### PR TITLE
Implement content library with Firestore pagination

### DIFF
--- a/lib/features/personal_app/ui/content_detail_screen.dart
+++ b/lib/features/personal_app/ui/content_detail_screen.dart
@@ -1,17 +1,55 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// TODO: Implement detailed content view
-class ContentDetailScreen extends StatelessWidget {
+import '../../../providers/content_library_provider.dart';
+import '../../../widgets/loading_state.dart';
+import '../../../widgets/error_state.dart';
+import '../../../theme/app_spacing.dart';
+
+class ContentDetailScreen extends ConsumerWidget {
   final String contentId;
 
   const ContentDetailScreen({super.key, required this.contentId});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final itemAsync = ref.watch(contentItemProvider(contentId));
     return Scaffold(
       appBar: AppBar(title: const Text('Content Detail')),
-      body: Center(
-        child: Text('Content ID: $contentId'),
+      body: itemAsync.when(
+        data: (item) {
+          if (item == null) {
+            return const Center(child: Text('Content not found'));
+          }
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (item.imageUrl.isNotEmpty)
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: Image.network(
+                      item.imageUrl,
+                      height: 200,
+                      width: double.infinity,
+                      fit: BoxFit.cover,
+                    ),
+                  ),
+                const SizedBox(height: AppSpacing.md),
+                Text(item.title,
+                    style: Theme.of(context).textTheme.headlineSmall),
+                const SizedBox(height: AppSpacing.sm),
+                Text('By ${item.author}',
+                    style: Theme.of(context).textTheme.labelMedium),
+                const SizedBox(height: AppSpacing.md),
+                Text(item.description),
+              ],
+            ),
+          );
+        },
+        loading: () => const LoadingState(),
+        error: (e, _) => ErrorState(title: 'Error', description: e.toString()),
       ),
     );
   }

--- a/lib/features/studio/ui/content_library_screen.dart
+++ b/lib/features/studio/ui/content_library_screen.dart
@@ -1,24 +1,83 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
-/// TODO: Implement content list per spec §2.2
-class ContentLibraryScreen extends StatelessWidget {
+import '../../../providers/content_library_provider.dart';
+import '../../../widgets/empty_state.dart';
+import '../../../widgets/loading_state.dart';
+import '../../../widgets/error_state.dart';
+
+class ContentLibraryScreen extends ConsumerStatefulWidget {
   const ContentLibraryScreen({super.key});
 
   @override
+  ConsumerState<ContentLibraryScreen> createState() =>
+      _ContentLibraryScreenState();
+}
+
+class _ContentLibraryScreenState extends ConsumerState<ContentLibraryScreen> {
+  final _controller = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(_onScroll);
+  }
+
+  void _onScroll() {
+    if (_controller.position.pixels >=
+        _controller.position.maxScrollExtent - 200) {
+      ref.read(contentLibraryProvider.notifier).loadMore();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final asyncItems = ref.watch(contentLibraryProvider);
+    final hasMore = ref.read(contentLibraryProvider.notifier).hasMore;
     return Scaffold(
       appBar: AppBar(
         title: const Text('Content Library'),
       ),
-      body: ListView(
-        children: [
-          Center(
-            child: Padding(
-              padding: EdgeInsets.all(24),
-              child: Text('No content available yet'),
-            ),
-          ),
-        ],
+      body: asyncItems.when(
+        data: (items) {
+          if (items.isEmpty) {
+            return const EmptyState(
+              title: 'No Content',
+              description: 'Content will appear here once available',
+            );
+          }
+          return ListView.builder(
+            controller: _controller,
+            itemCount: hasMore ? items.length + 1 : items.length,
+            itemBuilder: (context, index) {
+              if (index >= items.length) {
+                return const Padding(
+                  padding: EdgeInsets.all(16),
+                  child: Center(child: CircularProgressIndicator()),
+                );
+              }
+              final item = items[index];
+              return ListTile(
+                leading: item.imageUrl.isNotEmpty
+                    ? Image.network(item.imageUrl,
+                        width: 56, height: 56, fit: BoxFit.cover)
+                    : const Icon(Icons.image, size: 56),
+                title: Text(item.title),
+                subtitle: Text(item.author),
+                onTap: () => context.push('/content/${item.id}'),
+              );
+            },
+          );
+        },
+        loading: () => const LoadingState(),
+        error: (e, _) => ErrorState(title: 'Error', description: e.toString()),
       ),
     );
   }

--- a/lib/models/content_item.dart
+++ b/lib/models/content_item.dart
@@ -1,0 +1,55 @@
+class ContentItem {
+  final String id;
+  final String title;
+  final String description;
+  final String imageUrl;
+  final String author;
+  final DateTime createdAt;
+
+  ContentItem({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.imageUrl,
+    required this.author,
+    required this.createdAt,
+  });
+
+  factory ContentItem.fromJson(Map<String, dynamic> json) {
+    return ContentItem(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      description: json['description'] as String,
+      imageUrl: json['imageUrl'] as String? ?? '',
+      author: json['author'] as String? ?? '',
+      createdAt: DateTime.parse(json['createdAt'] as String),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'title': title,
+        'description': description,
+        'imageUrl': imageUrl,
+        'author': author,
+        'createdAt': createdAt.toIso8601String(),
+      };
+
+  ContentItem copyWith({
+    String? id,
+    String? title,
+    String? description,
+    String? imageUrl,
+    String? author,
+    DateTime? createdAt,
+  }) {
+    return ContentItem(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      imageUrl: imageUrl ?? this.imageUrl,
+      author: author ?? this.author,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+}

--- a/lib/providers/content_library_provider.dart
+++ b/lib/providers/content_library_provider.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../models/content_item.dart';
+import '../services/content_library_service.dart';
+
+final contentLibraryServiceProvider =
+    Provider<ContentLibraryService>((ref) => ContentLibraryService());
+
+class ContentLibraryNotifier
+    extends StateNotifier<AsyncValue<List<ContentItem>>> {
+  final ContentLibraryService _service;
+  DocumentSnapshot<Map<String, dynamic>>? _lastDoc;
+  bool _hasMore = true;
+
+  ContentLibraryNotifier(this._service) : super(const AsyncValue.loading()) {
+    load();
+  }
+
+  bool get hasMore => _hasMore;
+
+  Future<void> load() async {
+    _lastDoc = null;
+    _hasMore = true;
+    try {
+      final res = await _service.fetchItems();
+      _lastDoc = res.lastDoc;
+      _hasMore = res.hasMore;
+      state = AsyncValue.data(res.items);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  Future<void> loadMore() async {
+    if (!_hasMore) return;
+    try {
+      final res = await _service.fetchItems(startAfter: _lastDoc);
+      _lastDoc = res.lastDoc;
+      _hasMore = res.hasMore;
+      state = state.whenData((items) => [...items, ...res.items]);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+}
+
+final contentLibraryProvider = StateNotifierProvider<ContentLibraryNotifier,
+    AsyncValue<List<ContentItem>>>(
+  (ref) => ContentLibraryNotifier(ref.read(contentLibraryServiceProvider)),
+);
+
+final contentItemProvider =
+    FutureProvider.family<ContentItem?, String>((ref, id) async {
+  final service = ref.read(contentLibraryServiceProvider);
+  return service.getItem(id);
+});

--- a/lib/services/content_library_service.dart
+++ b/lib/services/content_library_service.dart
@@ -1,0 +1,51 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../models/content_item.dart';
+
+class PaginatedContent {
+  final List<ContentItem> items;
+  final DocumentSnapshot<Map<String, dynamic>>? lastDoc;
+  final bool hasMore;
+
+  PaginatedContent({
+    required this.items,
+    required this.lastDoc,
+    required this.hasMore,
+  });
+}
+
+class ContentLibraryService {
+  final FirebaseFirestore _firestore;
+  ContentLibraryService({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  CollectionReference<Map<String, dynamic>> get _col =>
+      _firestore.collection('content_items');
+
+  Future<PaginatedContent> fetchItems({
+    DocumentSnapshot<Map<String, dynamic>>? startAfter,
+    int limit = 10,
+  }) async {
+    Query<Map<String, dynamic>> q =
+        _col.orderBy('createdAt', descending: true).limit(limit);
+    if (startAfter != null) {
+      q = q.startAfterDocument(startAfter);
+    }
+    final snap = await q.get();
+    final items = snap.docs
+        .map((d) => ContentItem.fromJson({...d.data(), 'id': d.id}))
+        .toList();
+    final last = snap.docs.isNotEmpty ? snap.docs.last : null;
+    return PaginatedContent(
+      items: items,
+      lastDoc: last,
+      hasMore: snap.docs.length == limit,
+    );
+  }
+
+  Future<ContentItem?> getItem(String id) async {
+    final doc = await _col.doc(id).get();
+    if (!doc.exists) return null;
+    return ContentItem.fromJson({...doc.data()!, 'id': doc.id});
+  }
+}


### PR DESCRIPTION
## Summary
- add `ContentItem` data model
- implement Firestore-backed `ContentLibraryService`
- create `ContentLibraryNotifier` with pagination
- build UI for content list and detail screens

## Testing
- `dart test --coverage` *(fails: Dart SDK version 3.3.0 < 3.4.0 required)*

------
https://chatgpt.com/codex/tasks/task_e_6862962b30808324981bdaafe20f2bc5