### PR TITLE
Ensure gen-l10n runs before CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,8 @@ jobs:
         with:
           name: coverage-report
           path: coverage/lcov.info
+      - name: Generate localizations
+        run: flutter gen-l10n
       - run: flutter build web
       - name: Stop emulators
         if: always()
@@ -383,6 +385,8 @@ jobs:
         with:
           name: coverage-report
           path: coverage/lcov.info
+      - name: Generate localizations
+        run: flutter gen-l10n
       - name: Build Web App
         run: flutter build web --release
       - name: Deploy to Firebase Hosting
@@ -484,6 +488,8 @@ jobs:
         with:
           name: coverage-report
           path: coverage/lcov.info
+      - name: Generate localizations
+        run: flutter gen-l10n
       - run: flutter build web
       - name: Run Smoke Tests
         run: |
@@ -583,6 +589,8 @@ jobs:
         with:
           name: coverage-report
           path: coverage/lcov.info
+      - name: Generate localizations
+        run: flutter gen-l10n
       - run: flutter build web
       - name: Run Security Scan
         run: |
@@ -675,6 +683,8 @@ jobs:
         with:
           name: coverage-report
           path: coverage/lcov.info
+      - name: Generate localizations
+        run: flutter gen-l10n
       - run: flutter build web
       - name: Notify on Success
         if: success()

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -58,6 +58,8 @@ jobs:
         run: dart test --coverage=coverage
       - name: Run Flutter integration tests
         run: flutter test integration_test --reporter=compact
+      - name: Generate localizations
+        run: flutter gen-l10n
       - run: flutter build web
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/flutter_web.yml
+++ b/.github/workflows/flutter_web.yml
@@ -87,6 +87,8 @@ jobs:
     - run: dart analyze
     - run: flutter test --coverage test/
     - run: flutter test integration_test
+    - name: Generate localizations
+      run: flutter gen-l10n
     - run: flutter build web --release
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Summary
- check localization getters - none missing
- run `flutter gen-l10n` before build steps in CI workflows

## Testing
- `dart test --coverage` *(fails: command not found / network)*

------
https://chatgpt.com/codex/tasks/task_e_6862962149f0832499b84e351c18a40d