### PR TITLE
Add reusable animation components

### DIFF
--- a/lib/widgets/animations/fade_slide_route.dart
+++ b/lib/widgets/animations/fade_slide_route.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+/// Page route that fades and slides the new screen into view.
+class FadeSlideRoute<T> extends PageRouteBuilder<T> {
+  FadeSlideRoute({
+    required WidgetBuilder builder,
+    this.duration = const Duration(milliseconds: 300),
+    this.direction = AxisDirection.right,
+  }) : super(
+          pageBuilder: (context, animation, secondaryAnimation) => builder(context),
+          transitionDuration: duration,
+          transitionsBuilder: (context, animation, secondaryAnimation, child) {
+            final offsetAnimation = Tween<Offset>(
+              begin: _offsetForDirection(direction),
+              end: Offset.zero,
+            ).animate(animation);
+            return SlideTransition(
+              position: offsetAnimation,
+              child: FadeTransition(opacity: animation, child: child),
+            );
+          },
+        );
+
+  /// Duration of the transition.
+  final Duration duration;
+
+  /// Direction from which the screen slides in.
+  final AxisDirection direction;
+
+  static Offset _offsetForDirection(AxisDirection direction) {
+    switch (direction) {
+      case AxisDirection.up:
+        return const Offset(0, 0.1);
+      case AxisDirection.down:
+        return const Offset(0, -0.1);
+      case AxisDirection.left:
+        return const Offset(0.1, 0);
+      case AxisDirection.right:
+        return const Offset(-0.1, 0);
+    }
+  }
+}
+
+/// Example usage:
+/// ```dart
+/// Navigator.of(context).push(FadeSlideRoute(
+///   builder: (_) => const NextScreen(),
+/// ));
+/// ```

--- a/lib/widgets/animations/list_item_entry.dart
+++ b/lib/widgets/animations/list_item_entry.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+/// Animates a list item when it first appears.
+class ListItemEntry extends StatefulWidget {
+  const ListItemEntry({
+    super.key,
+    required this.child,
+    this.duration = const Duration(milliseconds: 300),
+    this.delay = Duration.zero,
+    this.offset = const Offset(0, 0.1),
+  });
+
+  /// The widget to animate in.
+  final Widget child;
+
+  /// Animation duration.
+  final Duration duration;
+
+  /// Delay before the animation starts.
+  final Duration delay;
+
+  /// Offset from which the item slides into place.
+  final Offset offset;
+
+  @override
+  State<ListItemEntry> createState() => _ListItemEntryState();
+}
+
+class _ListItemEntryState extends State<ListItemEntry>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<Offset> _offsetAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: widget.duration);
+    _offsetAnimation = Tween<Offset>(begin: widget.offset, end: Offset.zero)
+        .animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
+    Future.delayed(widget.delay, _controller.forward);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FadeTransition(
+      opacity: _controller,
+      child: SlideTransition(
+        position: _offsetAnimation,
+        child: widget.child,
+      ),
+    );
+  }
+}
+
+/// Example usage inside ListView.builder:
+/// ```dart
+/// ListView.builder(
+///   itemCount: items.length,
+///   itemBuilder: (_, index) => ListItemEntry(
+///     delay: Duration(milliseconds: index * 50),
+///     child: ListTile(title: Text(items[index])),
+///   ),
+/// );
+/// ```

--- a/lib/widgets/animations/press_feedback.dart
+++ b/lib/widgets/animations/press_feedback.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+
+/// Provides a subtle scale animation when the child is pressed.
+class PressFeedback extends StatefulWidget {
+  const PressFeedback({
+    super.key,
+    required this.child,
+    this.onTap,
+    this.duration = const Duration(milliseconds: 100),
+    this.scale = 0.95,
+  });
+
+  /// Widget below this widget in the tree.
+  final Widget child;
+
+  /// Callback when the child is tapped.
+  final VoidCallback? onTap;
+
+  /// Animation duration for press/release.
+  final Duration duration;
+
+  /// Scale factor when pressed.
+  final double scale;
+
+  @override
+  State<PressFeedback> createState() => _PressFeedbackState();
+}
+
+class _PressFeedbackState extends State<PressFeedback> {
+  bool _pressed = false;
+
+  void _setPressed(bool value) {
+    if (_pressed != value) {
+      setState(() => _pressed = value);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTapDown: (_) => _setPressed(true),
+      onTapUp: (_) => _setPressed(false),
+      onTapCancel: () => _setPressed(false),
+      onTap: widget.onTap,
+      child: AnimatedScale(
+        scale: _pressed ? widget.scale : 1.0,
+        duration: widget.duration,
+        child: widget.child,
+      ),
+    );
+  }
+}
+
+/// Example usage:
+/// ```dart
+/// PressFeedback(
+///   onTap: () {},
+///   child: const Icon(Icons.favorite),
+/// );
+/// ```


### PR DESCRIPTION
## Summary
- create PressFeedback for button touch animations
- add FadeSlideRoute for animated page transitions
- implement ListItemEntry for list item intro animations

## Testing
- `firebase emulators:start --only auth,firestore,storage` *(fails: command not found)*
- `dart test --coverage` *(fails to run due to SDK/version issues)*

------
https://chatgpt.com/codex/tasks/task_e_6862964dbaac83248e2142b62557804a