### PR TITLE
Add proxy setup docs

### DIFF
--- a/docs/github_actions_proxy_setup.md
+++ b/docs/github_actions_proxy_setup.md
@@ -1,0 +1,27 @@
+# GitHub Actions Proxy & Mirror Setup
+
+Use these environment variables to bypass `storage.googleapis.com` restrictions when running CI pipelines.
+
+## YAML
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      PUB_HOSTED_URL: https://pub.flutter-io.cn
+      FLUTTER_STORAGE_BASE_URL: https://storage.flutter-io.cn
+      http_proxy: http://proxy.example.com:3128
+      https_proxy: http://proxy.example.com:3128
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: flutter pub get
+```
+
+## Shell
+```bash
+export PUB_HOSTED_URL="https://pub.flutter-io.cn"
+export FLUTTER_STORAGE_BASE_URL="https://storage.flutter-io.cn"
+export http_proxy="http://proxy.example.com:3128"
+export https_proxy="$http_proxy"
+```


### PR DESCRIPTION
## Summary
- document how to set proxy and mirror variables for GitHub Actions

## Testing
- `firebase emulators:start --only auth,firestore,storage` *(failed: blocked domain)*
- `dart test --coverage` *(failed: blocked domain)*

------
https://chatgpt.com/codex/tasks/task_e_68629be222648324a492a71e08fc3513