### PR TITLE
Add integration load and stress tests

### DIFF
--- a/integration_test/booking_chat_load_test.dart
+++ b/integration_test/booking_chat_load_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:appoint/main.dart' as app;
+
+void main() {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized()
+      as IntegrationTestWidgetsFlutterBinding;
+
+  group('Booking Chat Load', () {
+    testWidgets('repeated chat booking flow', (tester) async {
+      await binding.watchPerformance(() async {
+        await app.appMain();
+        await tester.pumpAndSettle();
+
+        final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+        navigator.pushNamed('/chat-booking');
+        await tester.pumpAndSettle();
+
+        Future<void> runFlow() async {
+          await tester.enterText(find.byType(TextField), 'Haircut');
+          await tester.testTextInput.receiveAction(TextInputAction.done);
+          await tester.pumpAndSettle();
+
+          await tester.enterText(find.byType(TextField), '2025-01-01');
+          await tester.testTextInput.receiveAction(TextInputAction.done);
+          await tester.pumpAndSettle();
+
+          await tester.enterText(find.byType(TextField), '10:00');
+          await tester.testTextInput.receiveAction(TextInputAction.done);
+          await tester.pumpAndSettle();
+
+          await tester.enterText(find.byType(TextField), 'None');
+          await tester.testTextInput.receiveAction(TextInputAction.done);
+          await tester.pumpAndSettle();
+
+          await tester.enterText(find.byType(TextField), 'yes');
+          await tester.testTextInput.receiveAction(TextInputAction.done);
+          await tester.pumpAndSettle();
+        }
+
+        for (var i = 0; i < 20; i++) {
+          await runFlow();
+        }
+      }, reportKey: 'booking_chat_load');
+
+      final report =
+          binding.reportData!['booking_chat_load'] as Map<String, dynamic>;
+      expect(report['90th_percentile_frame_build_time_millis'] < 16.0, isTrue);
+    });
+  });
+}

--- a/integration_test/dashboard_navigation_stress_test.dart
+++ b/integration_test/dashboard_navigation_stress_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:appoint/main.dart' as app;
+
+void main() {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized()
+      as IntegrationTestWidgetsFlutterBinding;
+
+  group('Dashboard Navigation Stress', () {
+    testWidgets('navigate to dashboard repeatedly', (tester) async {
+      await binding.watchPerformance(() async {
+        await app.appMain();
+        await tester.pumpAndSettle();
+
+        final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+        for (var i = 0; i < 50; i++) {
+          navigator.pushNamed('/dashboard');
+          await tester.pumpAndSettle();
+          expect(find.text('Dashboard'), findsOneWidget);
+          await tester.pageBack();
+          await tester.pumpAndSettle();
+        }
+      }, reportKey: 'dashboard_navigation_stress');
+
+      final report = binding.reportData!['dashboard_navigation_stress']
+          as Map<String, dynamic>;
+      expect(report['average_frame_build_time_millis'] < 16.0, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add booking chat load test
- add dashboard navigation stress test

## Testing
- `dart test --coverage` *(fails: `storage.googleapis.com` blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68629c186b308324a08d7a7c3d593ba7