### PR TITLE
Resolve content management merge conflicts

### DIFF
--- a/lib/features/personal_app/ui/content_detail_screen.dart
+++ b/lib/features/personal_app/ui/content_detail_screen.dart
@@ -1,3 +1,4 @@
+// Displays a single content item retrieved from Firestore.
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/features/studio/ui/content_library_screen.dart
+++ b/lib/features/studio/ui/content_library_screen.dart
@@ -1,3 +1,4 @@
+// This screen fetches and paginates content items from Firestore.
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/models/content_item.dart
+++ b/lib/models/content_item.dart
@@ -1,3 +1,4 @@
+// Model representing a stored content record in Firestore.
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 /// Represents a piece of content in the library.


### PR DESCRIPTION
## Summary
- clarify Firestore usage in content library and detail screens
- clarify Firestore mapping in `ContentItem`

## Testing
- `firebase emulators:start --only auth,firestore,storage` *(fails: command not found)*
- `dart test --coverage` *(fails: SDK version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_6862a022f45c8324958fdbdd50f8c024