### PR TITLE
Add l10n getter audit script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,8 @@ jobs:
           path: coverage/lcov.info
       - name: Generate localizations
         run: flutter gen-l10n
+      - name: Check for undefined localization getters
+        run: dart scripts/check_l10n_getters.dart
       - run: flutter build web
       - name: Stop emulators
         if: always()

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -62,6 +62,8 @@ jobs:
       - run: dart run build_runner build --delete-conflicting-outputs --offline
       - name: Generate localizations
         run: flutter gen-l10n
+      - name: Check for undefined localization getters
+        run: dart scripts/check_l10n_getters.dart
       - run: flutter test --coverage
       - name: Calculate coverage
         id: cov

--- a/scripts/check_l10n_getters.dart
+++ b/scripts/check_l10n_getters.dart
@@ -1,0 +1,35 @@
+import 'dart:io';
+import 'dart:convert';
+
+void main() async {
+  final arbFile = File('lib/l10n/app_en.arb');
+  if (!arbFile.existsSync()) {
+    stderr.writeln('lib/l10n/app_en.arb not found');
+    exit(1);
+  }
+  final arbMap = jsonDecode(await arbFile.readAsString()) as Map<String, dynamic>;
+  final keys = <String>{};
+
+  await for (final entity in Directory('lib').list(recursive: true)) {
+    if (entity is! File || !entity.path.endsWith('.dart')) continue;
+    final lines = await entity.readAsLines();
+    for (final line in lines) {
+      if (line.trimLeft().startsWith('//')) continue;
+      final regex = RegExp(r'l10n\.([a-zA-Z0-9_]+)');
+      for (final match in regex.allMatches(line)) {
+        keys.add(match.group(1)!);
+      }
+    }
+  }
+
+  final missing = keys.where((k) => !arbMap.containsKey(k) && k != 'localeName');
+  if (missing.isNotEmpty) {
+    stderr.writeln('Missing localization keys:');
+    for (final k in missing) {
+      stderr.writeln('  $k');
+    }
+    exit(1);
+  } else {
+    print('All localization getters defined.');
+  }
+}


### PR DESCRIPTION
## Summary
- detect undefined localization getters with new script
- run the getter check in CI workflows

## Testing
- `dart scripts/check_l10n_getters.dart`
- `flutter gen-l10n` *(no output)*
- `dart test --coverage` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_6862a04ac0a88324a2d4b697ba0f2395