### PR TITLE
Enable Dart test coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,8 +122,8 @@ jobs:
           (firebase emulators:start --only firestore,auth,storage || sleep 5 && firebase emulators:start --only firestore,auth,storage) &
           echo $! > emulator.pid
       - run: flutter pub downgrade || true
-      - name: Run Flutter tests with coverage
-        run: flutter test --coverage
+      - name: Run Dart tests with coverage
+        run: dart test --coverage
       - name: Run Flutter integration tests
         run: flutter test integration_test --reporter=compact
       - name: Upload coverage artifact
@@ -218,8 +218,8 @@ jobs:
       - run: flutter analyze
       - run: dart analyze
       - run: flutter pub downgrade || true
-      - name: Run Flutter tests with coverage
-        run: flutter test --coverage test/features/studio/content_library_screen_test.dart
+      - name: Run Dart tests with coverage
+        run: dart test --coverage test/features/studio/content_library_screen_test.dart
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3
         with:
@@ -371,8 +371,8 @@ jobs:
       - run: flutter analyze
       - run: dart analyze
       - run: flutter pub downgrade || true
-      - name: Run Flutter tests with coverage
-        run: flutter test --coverage
+      - name: Run Dart tests with coverage
+        run: dart test --coverage
       - run: flutter test integration_test
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3
@@ -467,8 +467,8 @@ jobs:
       - run: flutter analyze
       - run: dart analyze
       - run: flutter pub downgrade || true
-      - name: Run Flutter tests with coverage
-        run: flutter test --coverage
+      - name: Run Dart tests with coverage
+        run: dart test --coverage
       - run: flutter test integration_test
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3
@@ -561,8 +561,8 @@ jobs:
       - run: flutter analyze
       - run: dart analyze
       - run: flutter pub downgrade || true
-      - name: Run Flutter tests with coverage
-        run: flutter test --coverage
+      - name: Run Dart tests with coverage
+        run: dart test --coverage
       - run: flutter test integration_test
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3
@@ -648,8 +648,8 @@ jobs:
       - run: flutter analyze
       - run: dart analyze
       - run: flutter pub downgrade || true
-      - name: Run Flutter tests with coverage
-        run: flutter test --coverage
+      - name: Run Dart tests with coverage
+        run: dart test --coverage
       - run: flutter test integration_test
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Summary
- switch all CI coverage steps to `dart test --coverage`

## Testing
- `bash scripts/run_tests.sh unit` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862a911f9e4832481dfda0ee268f8b8