### PR TITLE
Fix workflow paths and remove proxy settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,7 @@ jobs:
       FLUTTER_STORAGE_BASE_URL: https://storage.flutter-io.cn
       FLUTTER_CACHE_DIR: ~/.flutter
       PUB_CACHE: ~/.pub-cache
-      http_proxy: http://proxy.example.com:3128
-      https_proxy: http://proxy.example.com:3128
+      PATH: /usr/local/flutter/bin:/usr/lib/dart/bin:$PATH
     services:
       firebase:
         image: cdrx/fake-firebase-emulator:latest
@@ -240,6 +239,7 @@ jobs:
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
       PUB_CACHE: ~/.pub-cache
+      PATH: /usr/local/flutter/bin:/usr/lib/dart/bin:$PATH
     steps:
       - uses: actions/checkout@v4
       - name: Check network access
@@ -304,6 +304,7 @@ jobs:
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
       PUB_CACHE: ~/.pub-cache
+      PATH: /usr/local/flutter/bin:/usr/lib/dart/bin:$PATH
     steps:
       - uses: actions/checkout@v4
       - name: Check network access
@@ -400,6 +401,7 @@ jobs:
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
       PUB_CACHE: ~/.pub-cache
+      PATH: /usr/local/flutter/bin:/usr/lib/dart/bin:$PATH
     steps:
       - uses: actions/checkout@v4
       - name: Check network access
@@ -494,6 +496,7 @@ jobs:
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
       PUB_CACHE: ~/.pub-cache
+      PATH: /usr/local/flutter/bin:/usr/lib/dart/bin:$PATH
     steps:
       - uses: actions/checkout@v4
       - name: Check network access
@@ -591,6 +594,7 @@ jobs:
       FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
       FLUTTER_CACHE_DIR: ~/.flutter
       PUB_CACHE: ~/.pub-cache
+      PATH: /usr/local/flutter/bin:/usr/lib/dart/bin:$PATH
     steps:
       - uses: actions/checkout@v4
       - name: Check network access

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -17,8 +17,7 @@ jobs:
       PUB_HOSTED_URL: https://pub.flutter-io.cn
       FLUTTER_STORAGE_BASE_URL: https://storage.flutter-io.cn
       FLUTTER_CACHE_DIR: ~/.flutter
-      http_proxy: http://proxy.example.com:3128
-      https_proxy: http://proxy.example.com:3128
+      PATH: /usr/local/flutter/bin:/usr/lib/dart/bin:$PATH
     steps:
       - uses: actions/checkout@v3
       - name: Setup Flutter

--- a/.github/workflows/flutter_web.yml
+++ b/.github/workflows/flutter_web.yml
@@ -16,8 +16,7 @@ jobs:
       PUB_HOSTED_URL: https://pub.flutter-io.cn
       FLUTTER_STORAGE_BASE_URL: https://storage.flutter-io.cn
       FLUTTER_CACHE_DIR: ~/.flutter
-      http_proxy: http://proxy.example.com:3128
-      https_proxy: http://proxy.example.com:3128
+      PATH: /usr/local/flutter/bin:/usr/lib/dart/bin:$PATH
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -17,8 +17,7 @@ jobs:
       PUB_HOSTED_URL: https://pub.flutter-io.cn
       FLUTTER_STORAGE_BASE_URL: https://storage.flutter-io.cn
       FLUTTER_CACHE_DIR: ~/.flutter
-      http_proxy: http://proxy.example.com:3128
-      https_proxy: http://proxy.example.com:3128
+      PATH: /usr/local/flutter/bin:/usr/lib/dart/bin:$PATH
     steps:
       - uses: actions/checkout@v3
       - name: Check network access

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -21,8 +21,7 @@ jobs:
     env:
       PUB_HOSTED_URL: https://pub.flutter-io.cn
       FLUTTER_STORAGE_BASE_URL: https://storage.flutter-io.cn
-      http_proxy: http://proxy.example.com:3128
-      https_proxy: http://proxy.example.com:3128
+      PATH: /usr/local/flutter/bin:/usr/lib/dart/bin:$PATH
     steps:
       - uses: actions/checkout@v4
       - name: Cache Flutter SDK


### PR DESCRIPTION
## Summary
- ensure Flutter and Dart are in PATH for every job
- remove placeholder proxy variables from workflows

## Testing
- `dart --version`
- `dart pub get` *(fails: domain not in allowlist)*
- `dart test --coverage` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_6862a9d46b048324a271837e423a777a