### PR TITLE
Update CI workflows for Dart 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
           - 5001:5001   # Functions
         env:
           FIREBASE_PROJECT: app-oint-core
-          PUB_HOSTED_URL: https://pub.dev
-          FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
+          PUB_HOSTED_URL: https://pub.flutter-io.cn
+          FLUTTER_STORAGE_BASE_URL: https://storage.flutter-io.cn
     steps:
       - uses: actions/checkout@v4
       # Install Flutter and cache the SDK so flutter and dart commands are available
@@ -100,7 +100,7 @@ jobs:
         run: verdaccio --config verdaccio.yaml & sleep 5
       - name: Configure Pub Cache
         run: |
-          echo "PUB_HOSTED_URL=http://localhost:4873" >> $GITHUB_ENV
+          echo "PUB_HOSTED_URL=https://pub.flutter-io.cn" >> $GITHUB_ENV
           echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
       - name: Check network access
         run: |
@@ -118,7 +118,7 @@ jobs:
         run: curl --fail https://storage.googleapis.com
       - run: flutter pub get
       - run: dart pub get
-      - run: dart run build_runner build --delete-conflicting-outputs --offline
+      - run: dart run build_runner build --delete-conflicting-outputs 
       - run: flutter analyze
       - run: dart analyze
       - name: Start Firebase emulators
@@ -158,8 +158,8 @@ jobs:
       image: ghcr.io/your-org/app-oint-dev:latest
       options: --pull
     env:
-      PUB_HOSTED_URL: http://localhost:4873
-      FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
+      PUB_HOSTED_URL: https://pub.flutter-io.cn
+      FLUTTER_STORAGE_BASE_URL: https://storage.flutter-io.cn
       FLUTTER_CACHE_DIR: ~/.flutter
       PUB_CACHE: ~/.pub-cache
     steps:
@@ -215,7 +215,7 @@ jobs:
         run: verdaccio --config verdaccio.yaml & sleep 5
       - name: Configure Pub Cache
         run: |
-          echo "PUB_HOSTED_URL=http://localhost:4873" >> $GITHUB_ENV
+          echo "PUB_HOSTED_URL=https://pub.flutter-io.cn" >> $GITHUB_ENV
           echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
       - name: Check network access
         run: |
@@ -231,9 +231,9 @@ jobs:
             ${{ runner.os }}-pub-
       - name: Check storage connectivity
         run: curl --fail https://storage.googleapis.com
-      - run: flutter pub get --offline
+      - run: flutter pub get 
       - run: dart pub get
-      - run: dart run build_runner build --delete-conflicting-outputs --offline
+      - run: dart run build_runner build --delete-conflicting-outputs 
       - run: flutter analyze
       - run: dart analyze
       - run: flutter pub downgrade || true
@@ -259,8 +259,8 @@ jobs:
       options: --pull
     if: github.ref == 'refs/heads/main'
     env:
-      PUB_HOSTED_URL: https://pub.dev
-      FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
+      PUB_HOSTED_URL: https://pub.flutter-io.cn
+      FLUTTER_STORAGE_BASE_URL: https://storage.flutter-io.cn
       FLUTTER_CACHE_DIR: ~/.flutter
       PUB_CACHE: ~/.pub-cache
       PATH: /usr/local/flutter/bin:/usr/lib/dart/bin:$PATH
@@ -330,8 +330,8 @@ jobs:
       options: --pull
     if: github.ref == 'refs/heads/main'
     env:
-      PUB_HOSTED_URL: http://localhost:4873
-      FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
+      PUB_HOSTED_URL: https://pub.flutter-io.cn
+      FLUTTER_STORAGE_BASE_URL: https://storage.flutter-io.cn
       FLUTTER_CACHE_DIR: ~/.flutter
       PUB_CACHE: ~/.pub-cache
       PATH: /usr/local/flutter/bin:/usr/lib/dart/bin:$PATH
@@ -388,7 +388,7 @@ jobs:
         run: verdaccio --config verdaccio.yaml & sleep 5
       - name: Configure Pub Cache
         run: |
-          echo "PUB_HOSTED_URL=http://localhost:4873" >> $GITHUB_ENV
+          echo "PUB_HOSTED_URL=https://pub.flutter-io.cn" >> $GITHUB_ENV
           echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
       - name: Check network access
         run: |
@@ -404,9 +404,9 @@ jobs:
             ${{ runner.os }}-pub-
       - name: Check storage connectivity
         run: curl --fail https://storage.googleapis.com
-      - run: flutter pub get --offline
+      - run: flutter pub get 
       - run: dart pub get
-      - run: dart run build_runner build --delete-conflicting-outputs --offline
+      - run: dart run build_runner build --delete-conflicting-outputs 
       - run: flutter analyze
       - run: dart analyze
       - run: flutter pub downgrade || true
@@ -439,8 +439,8 @@ jobs:
       options: --pull
     if: github.ref == 'refs/heads/main'
     env:
-      PUB_HOSTED_URL: http://localhost:4873
-      FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
+      PUB_HOSTED_URL: https://pub.flutter-io.cn
+      FLUTTER_STORAGE_BASE_URL: https://storage.flutter-io.cn
       FLUTTER_CACHE_DIR: ~/.flutter
       PUB_CACHE: ~/.pub-cache
       PATH: /usr/local/flutter/bin:/usr/lib/dart/bin:$PATH
@@ -497,7 +497,7 @@ jobs:
         run: verdaccio --config verdaccio.yaml & sleep 5
       - name: Configure Pub Cache
         run: |
-          echo "PUB_HOSTED_URL=http://localhost:4873" >> $GITHUB_ENV
+          echo "PUB_HOSTED_URL=https://pub.flutter-io.cn" >> $GITHUB_ENV
           echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
       - name: Check network access
         run: |
@@ -513,9 +513,9 @@ jobs:
             ${{ runner.os }}-pub-
       - name: Check storage connectivity
         run: curl --fail https://storage.googleapis.com
-      - run: flutter pub get --offline
+      - run: flutter pub get 
       - run: dart pub get
-      - run: dart run build_runner build --delete-conflicting-outputs --offline
+      - run: dart run build_runner build --delete-conflicting-outputs 
       - run: flutter analyze
       - run: dart analyze
       - run: flutter pub downgrade || true
@@ -546,8 +546,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     env:
-      PUB_HOSTED_URL: http://localhost:4873
-      FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
+      PUB_HOSTED_URL: https://pub.flutter-io.cn
+      FLUTTER_STORAGE_BASE_URL: https://storage.flutter-io.cn
       FLUTTER_CACHE_DIR: ~/.flutter
       PUB_CACHE: ~/.pub-cache
       PATH: /usr/local/flutter/bin:/usr/lib/dart/bin:$PATH
@@ -604,7 +604,7 @@ jobs:
         run: verdaccio --config verdaccio.yaml & sleep 5
       - name: Configure Pub Cache
         run: |
-          echo "PUB_HOSTED_URL=http://localhost:4873" >> $GITHUB_ENV
+          echo "PUB_HOSTED_URL=https://pub.flutter-io.cn" >> $GITHUB_ENV
           echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
       - name: Check network access
         run: |
@@ -620,9 +620,9 @@ jobs:
             ${{ runner.os }}-pub-
       - name: Check storage connectivity
         run: curl --fail https://storage.googleapis.com
-      - run: flutter pub get --offline
+      - run: flutter pub get 
       - run: dart pub get
-      - run: dart run build_runner build --delete-conflicting-outputs --offline
+      - run: dart run build_runner build --delete-conflicting-outputs 
       - run: flutter analyze
       - run: dart analyze
       - run: flutter pub downgrade || true
@@ -656,8 +656,8 @@ jobs:
       options: --pull
     if: always()
     env:
-      PUB_HOSTED_URL: http://localhost:4873
-      FLUTTER_STORAGE_BASE_URL: https://storage.googleapis.com
+      PUB_HOSTED_URL: https://pub.flutter-io.cn
+      FLUTTER_STORAGE_BASE_URL: https://storage.flutter-io.cn
       FLUTTER_CACHE_DIR: ~/.flutter
       PUB_CACHE: ~/.pub-cache
       PATH: /usr/local/flutter/bin:/usr/lib/dart/bin:$PATH
@@ -710,7 +710,7 @@ jobs:
         run: verdaccio --config verdaccio.yaml & sleep 5
       - name: Configure Pub Cache
         run: |
-          echo "PUB_HOSTED_URL=http://localhost:4873" >> $GITHUB_ENV
+          echo "PUB_HOSTED_URL=https://pub.flutter-io.cn" >> $GITHUB_ENV
           echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
       - name: Check network access
         run: |
@@ -720,9 +720,9 @@ jobs:
           curl --fail https://firebase-public.firebaseio.com
       - name: Check storage connectivity
         run: curl --fail https://storage.googleapis.com
-      - run: flutter pub get --offline
+      - run: flutter pub get 
       - run: dart pub get
-      - run: dart run build_runner build --delete-conflicting-outputs --offline
+      - run: dart run build_runner build --delete-conflicting-outputs 
       - run: flutter analyze
       - run: dart analyze
       - run: flutter pub downgrade || true

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -51,14 +51,20 @@ jobs:
       - name: "Pre-flight: Verify Dart"
         run: |
           which dart
-          dart --version
+          version_line=$(dart --version 2>&1)
+          echo "$version_line"
+          sdk=$(echo "$version_line" | awk '{print $4}')
+          required=3.4.0
+          if [ "$(printf '%s\n%s\n' "$required" "$sdk" | sort -V | head -n1)" != "$required" ]; then
+            echo "Dart SDK $sdk is below required $required" && exit 1
+          fi
       # network checks removed for offline usage
       - name: Get dependencies
         run: flutter pub get
       - run: dart pub get
       - name: Verify firebase_app_check resolution
         run: grep firebase_app_check pubspec.lock
-      - run: dart run build_runner build --delete-conflicting-outputs --offline
+      - run: dart run build_runner build --delete-conflicting-outputs
       - run: flutter analyze
       - run: dart analyze
       - name: Start Firebase emulators
@@ -69,7 +75,7 @@ jobs:
           firebase emulators:start --only auth,firestore,storage --project app-oint-core &
           sleep 5
       - name: Run Flutter tests with coverage
-        run: flutter test --coverage
+        run: dart test --coverage
       - name: Run Flutter integration tests
         run: flutter test integration_test --reporter=compact
       - name: Generate localizations

--- a/.github/workflows/flutter_web.yml
+++ b/.github/workflows/flutter_web.yml
@@ -67,8 +67,14 @@ jobs:
         scripts/update_network_allowlist.sh ${{ secrets.GHE_ENTERPRISE }} ${{ secrets.GHE_TOKEN }}
     - name: "Pre-flight: Verify network & Dart"
       run: |
-    which dart
-        dart --version
+        which dart
+        version_line=$(dart --version 2>&1)
+        echo "$version_line"
+        sdk=$(echo "$version_line" | awk '{print $4}')
+        required=3.4.0
+        if [ "$(printf '%s\n%s\n' "$required" "$sdk" | sort -V | head -n1)" != "$required" ]; then
+          echo "Dart SDK $sdk is below required $required" && exit 1
+        fi
         curl --fail https://firebase-public.firebaseio.com
         curl --fail https://storage.googleapis.com
         for host in storage.googleapis.com pub.dev raw.githubusercontent.com dart.dev firebase.google.com; do
@@ -82,9 +88,9 @@ jobs:
         curl --fail https://dart.dev
         curl --fail https://pub.dev
         curl --fail https://firebase-public.firebaseio.com
-    - run: flutter pub get --offline
+    - run: flutter pub get
     - run: dart pub get
-    - run: dart run build_runner build --delete-conflicting-outputs --offline
+    - run: dart run build_runner build --delete-conflicting-outputs
     - name: Configure offline pub cache
       run: echo "PUB_CACHE=third_party/pub_cache" >> $GITHUB_ENV
     - name: Check storage connectivity
@@ -96,10 +102,10 @@ jobs:
         curl --fail https://pub.dev
         curl --fail https://firebase-public.firebaseio.com
     - name: Fetch dependencies offline
-      run: flutter pub get --offline
+      run: flutter pub get
     - run: flutter analyze
     - run: dart analyze
-    - run: flutter test --coverage test/
+    - run: dart test --coverage
     - run: flutter test integration_test
     - name: Generate localizations
       run: flutter gen-l10n

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -62,8 +62,14 @@ jobs:
           scripts/update_network_allowlist.sh ${{ secrets.GHE_ENTERPRISE }} ${{ secrets.GHE_TOKEN }}
       - name: "Pre-flight: Verify network & Dart"
         run: |
-    which dart
-          dart --version
+          which dart
+          version_line=$(dart --version 2>&1)
+          echo "$version_line"
+          sdk=$(echo "$version_line" | awk '{print $4}')
+          required=3.4.0
+          if [ "$(printf '%s\n%s\n' "$required" "$sdk" | sort -V | head -n1)" != "$required" ]; then
+            echo "Dart SDK $sdk is below required $required" && exit 1
+          fi
           curl --fail https://firebase-public.firebaseio.com
           curl --fail https://storage.googleapis.com
           for host in pub.dev storage.googleapis.com firebase-public.firebaseio.com metadata.google.internal 169.254.169.254 raw.githubusercontent.com dart.dev; do
@@ -84,9 +90,9 @@ jobs:
           curl --fail https://dart.dev
           curl --fail https://pub.dev
           curl --fail https://firebase-public.firebaseio.com
-      - run: flutter pub get --offline
+      - run: flutter pub get
       - run: dart pub get
-      - run: dart run build_runner build --delete-conflicting-outputs --offline
+      - run: dart run build_runner build --delete-conflicting-outputs
       - name: Check storage connectivity
         run: curl --fail https://storage.googleapis.com
       - name: Configure offline pub cache
@@ -98,11 +104,11 @@ jobs:
           curl --fail https://pub.dev
           curl --fail https://firebase-public.firebaseio.com
       - name: Fetch dependencies offline
-        run: flutter pub get --offline
+        run: flutter pub get
       - run: flutter analyze
       - run: dart analyze
       - name: Run Flutter tests with coverage
-        run: flutter test --coverage
+        run: dart test --coverage
       - run: flutter test integration_test
       - run: flutter build web
       - name: Upload coverage artifact

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -56,19 +56,25 @@ jobs:
       - name: Pre-flight: Verify Dart
         run: |
           which dart
-          dart --version
+          version_line=$(dart --version 2>&1)
+          echo "$version_line"
+          sdk=$(echo "$version_line" | awk '{print $4}')
+          required=3.4.0
+          if [ "$(printf '%s\n%s\n' "$required" "$sdk" | sort -V | head -n1)" != "$required" ]; then
+            echo "Dart SDK $sdk is below required $required" && exit 1
+          fi
       # network checks removed for offline usage
       - run: flutter pub get
       - name: Check Dart formatting
         run: dart format --output=none --set-exit-if-changed .
       - name: Analyze code
         run: flutter analyze
-      - run: dart run build_runner build --delete-conflicting-outputs --offline
+      - run: dart run build_runner build --delete-conflicting-outputs
       - name: Generate localizations
         run: flutter gen-l10n
       - name: Check for undefined localization getters
         run: dart scripts/check_l10n_getters.dart
-      - run: flutter test --coverage
+      - run: dart test --coverage
       - name: Calculate coverage
         id: cov
         run: |


### PR DESCRIPTION
## Summary
- ensure all workflows use Flutter 3.32 and Dart 3.4
- rely on pub.flutter-io.cn and storage.flutter-io.cn mirrors
- run dependency resolution online
- verify Dart version before running tests
- run `dart test --coverage`

## Testing
- `dart pub get` *(failed: domain is not in allowlist)*
- `dart test --coverage` *(failed: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_6862af917b3c83248aa11819825368f7