### PR TITLE
Enable coverage for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
             --lcov --in=coverage --out=coverage/lcov.info \
             --packages=.dart_tool/package_config.json --report-on=lib
       - name: Run Flutter integration tests
-        run: flutter test integration_test --reporter=compact
+        run: flutter test integration_test --coverage --reporter=compact
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3
         with:
@@ -418,7 +418,7 @@ jobs:
           dart pub global run coverage:format_coverage \
             --lcov --in=coverage --out=coverage/lcov.info \
             --packages=.dart_tool/package_config.json --report-on=lib
-      - run: flutter test integration_test
+      - run: flutter test integration_test --coverage
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3
         with:
@@ -527,7 +527,7 @@ jobs:
           dart pub global run coverage:format_coverage \
             --lcov --in=coverage --out=coverage/lcov.info \
             --packages=.dart_tool/package_config.json --report-on=lib
-      - run: flutter test integration_test
+      - run: flutter test integration_test --coverage
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3
         with:
@@ -634,7 +634,7 @@ jobs:
           dart pub global run coverage:format_coverage \
             --lcov --in=coverage --out=coverage/lcov.info \
             --packages=.dart_tool/package_config.json --report-on=lib
-      - run: flutter test integration_test
+      - run: flutter test integration_test --coverage
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3
         with:
@@ -734,7 +734,7 @@ jobs:
           dart pub global run coverage:format_coverage \
             --lcov --in=coverage --out=coverage/lcov.info \
             --packages=.dart_tool/package_config.json --report-on=lib
-      - run: flutter test integration_test
+      - run: flutter test integration_test --coverage
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -77,9 +77,11 @@ jobs:
       - name: Run Flutter tests with coverage
         run: dart test --coverage
       - name: Run Flutter integration tests
-        run: flutter test integration_test --reporter=compact
+        run: flutter test integration_test --coverage --reporter=compact
       - name: Generate localizations
         run: flutter gen-l10n
+      - name: Check for undefined localization getters
+        run: dart scripts/check_l10n_getters.dart
       - run: flutter build web
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/flutter_web.yml
+++ b/.github/workflows/flutter_web.yml
@@ -106,9 +106,11 @@ jobs:
     - run: flutter analyze
     - run: dart analyze
     - run: dart test --coverage
-    - run: flutter test integration_test
+    - run: flutter test integration_test --coverage
     - name: Generate localizations
       run: flutter gen-l10n
+    - name: Check for undefined localization getters
+      run: dart scripts/check_l10n_getters.dart
     - run: flutter build web --release
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -109,7 +109,7 @@ jobs:
       - run: dart analyze
       - name: Run Flutter tests with coverage
         run: dart test --coverage
-      - run: flutter test integration_test
+      - run: flutter test integration_test --coverage
       - run: flutter build web
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3
@@ -145,6 +145,8 @@ jobs:
         run: dart scripts/merge_l10n.dart
       - name: Generate localizations
         run: flutter gen-l10n
+      - name: Check for undefined localization getters
+        run: dart scripts/check_l10n_getters.dart
       - name: Verify generated files
         run: |
           echo "Checking generated localization files..."


### PR DESCRIPTION
## Summary
- run integration tests with coverage in all workflows
- validate localization getters in `flutter` and `flutter_web` jobs

## Testing
- `./scripts/run_tests.sh unit` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b3f22c7083249264b3dcdae64dc0