### PR TITLE
Add Terraform monitoring stack

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,61 @@
+terraform {
+  required_version = ">= 1.3"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.20"
+    }
+    kubernetes-alpha = {
+      source  = "hashicorp/kubernetes-alpha"
+      version = ">= 0.7"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.13"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "kubernetes" {
+  config_path = var.kubeconfig_path
+}
+
+provider "kubernetes-alpha" {
+  config_path = var.kubeconfig_path
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = var.kubeconfig_path
+  }
+}
+
+module "observability" {
+  source                = "./modules/observability"
+  namespace             = var.monitoring_namespace
+  metrics_retention_days = var.metrics_retention_days
+  trace_retention_days   = var.trace_retention_days
+}
+
+module "log_bucket" {
+  source            = "./modules/log_bucket"
+  bucket_name       = var.log_bucket_name
+  log_retention_days = var.log_retention_days
+}
+
+module "alerts" {
+  source                 = "./modules/alerts"
+  namespace              = var.monitoring_namespace
+  api_uptime_target      = var.api_uptime_target
+  api_p95_latency_ms     = var.api_p95_latency_ms
+  api_p99_latency_ms     = var.api_p99_latency_ms
+  booking_success_target = var.booking_success_target
+}

--- a/terraform/modules/alerts/api_availability.yaml.tmpl
+++ b/terraform/modules/alerts/api_availability.yaml.tmpl
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: api-availability-slo
+  namespace: ${namespace}
+spec:
+  groups:
+  - name: api-availability
+    rules:
+    - alert: ApiAvailabilitySLO
+      expr: (sum_over_time(up{job="appoint-api"}[5m]) / 5) * 100 < ${api_uptime_target}
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: "API availability below ${api_uptime_target}% over 5m"
+        description: "API availability has been under ${api_uptime_target}% for the last 5 minutes."

--- a/terraform/modules/alerts/api_latency.yaml.tmpl
+++ b/terraform/modules/alerts/api_latency.yaml.tmpl
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: api-latency-slo
+  namespace: ${namespace}
+spec:
+  groups:
+  - name: api-latency
+    rules:
+    - alert: ApiLatencyP95
+      expr: histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job="appoint-api"}[5m])) by (le)) * 1000 > ${api_p95_latency_ms}
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: "API p95 latency above ${api_p95_latency_ms}ms"
+        description: "p95 API latency > ${api_p95_latency_ms}ms over 5 minutes."
+    - alert: ApiLatencyP99
+      expr: histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job="appoint-api"}[5m])) by (le)) * 1000 > ${api_p99_latency_ms}
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: "API p99 latency above ${api_p99_latency_ms}ms"
+        description: "p99 API latency > ${api_p99_latency_ms}ms over 5 minutes."

--- a/terraform/modules/alerts/booking_success.yaml.tmpl
+++ b/terraform/modules/alerts/booking_success.yaml.tmpl
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: booking-success-rate
+  namespace: ${namespace}
+spec:
+  groups:
+  - name: booking-success
+    rules:
+    - alert: BookingSuccessRateLow
+      expr: (sum(rate(booking_success_total[10m])) / sum(rate(booking_requests_total[10m]))) * 100 < ${booking_success_target}
+      for: 10m
+      labels:
+        severity: critical
+      annotations:
+        summary: "Booking success rate below ${booking_success_target}%"
+        description: "Booking success rate has been < ${booking_success_target}% for 10 minutes."

--- a/terraform/modules/alerts/main.tf
+++ b/terraform/modules/alerts/main.tf
@@ -1,0 +1,36 @@
+data "template_file" "api_availability" {
+  template = file("${path.module}/api_availability.yaml.tmpl")
+  vars = {
+    namespace         = var.namespace
+    api_uptime_target = var.api_uptime_target
+  }
+}
+
+resource "kubernetes_manifest" "api_availability" {
+  manifest = yamldecode(data.template_file.api_availability.rendered)
+}
+
+data "template_file" "api_latency" {
+  template = file("${path.module}/api_latency.yaml.tmpl")
+  vars = {
+    namespace            = var.namespace
+    api_p95_latency_ms   = var.api_p95_latency_ms
+    api_p99_latency_ms   = var.api_p99_latency_ms
+  }
+}
+
+resource "kubernetes_manifest" "api_latency" {
+  manifest = yamldecode(data.template_file.api_latency.rendered)
+}
+
+data "template_file" "booking_success" {
+  template = file("${path.module}/booking_success.yaml.tmpl")
+  vars = {
+    namespace              = var.namespace
+    booking_success_target = var.booking_success_target
+  }
+}
+
+resource "kubernetes_manifest" "booking_success" {
+  manifest = yamldecode(data.template_file.booking_success.rendered)
+}

--- a/terraform/modules/alerts/variables.tf
+++ b/terraform/modules/alerts/variables.tf
@@ -1,0 +1,24 @@
+variable "namespace" {
+  description = "Namespace where alert rules will be created"
+  type        = string
+}
+
+variable "api_uptime_target" {
+  description = "Target uptime percentage for API"
+  type        = number
+}
+
+variable "api_p95_latency_ms" {
+  description = "p95 latency threshold in milliseconds"
+  type        = number
+}
+
+variable "api_p99_latency_ms" {
+  description = "p99 latency threshold in milliseconds"
+  type        = number
+}
+
+variable "booking_success_target" {
+  description = "Booking success rate threshold percentage"
+  type        = number
+}

--- a/terraform/modules/log_bucket/main.tf
+++ b/terraform/modules/log_bucket/main.tf
@@ -1,0 +1,16 @@
+resource "aws_s3_bucket" "logs" {
+  bucket = var.bucket_name
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "log_lifecycle" {
+  bucket = aws_s3_bucket.logs.id
+
+  rule {
+    id     = "log-retention"
+    status = "Enabled"
+
+    expiration {
+      days = var.log_retention_days
+    }
+  }
+}

--- a/terraform/modules/log_bucket/variables.tf
+++ b/terraform/modules/log_bucket/variables.tf
@@ -1,0 +1,9 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket for logs"
+  type        = string
+}
+
+variable "log_retention_days" {
+  description = "Number of days to retain logs"
+  type        = number
+}

--- a/terraform/modules/observability/main.tf
+++ b/terraform/modules/observability/main.tf
@@ -1,0 +1,36 @@
+locals {
+  metrics_retention_str = format("%dd", var.metrics_retention_days)
+  trace_retention_str   = format("%dd", var.trace_retention_days)
+}
+
+resource "helm_release" "kube_prometheus_stack" {
+  name       = "kube-prometheus-stack"
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart      = "kube-prometheus-stack"
+  namespace  = var.namespace
+
+  values = [
+    yamlencode({
+      prometheus = {
+        prometheusSpec = {
+          retention = local.metrics_retention_str
+        }
+      }
+    })
+  ]
+}
+
+resource "helm_release" "tempo" {
+  name       = "tempo"
+  repository = "https://grafana.github.io/helm-charts"
+  chart      = "tempo"
+  namespace  = var.namespace
+
+  values = [
+    yamlencode({
+      retention = {
+        time = local.trace_retention_str
+      }
+    })
+  ]
+}

--- a/terraform/modules/observability/variables.tf
+++ b/terraform/modules/observability/variables.tf
@@ -1,0 +1,14 @@
+variable "namespace" {
+  description = "Kubernetes namespace for observability components"
+  type        = string
+}
+
+variable "metrics_retention_days" {
+  description = "Retention time for Prometheus metrics in days"
+  type        = number
+}
+
+variable "trace_retention_days" {
+  description = "Retention time for traces in days"
+  type        = number
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,57 @@
+variable "aws_region" {
+  description = "AWS region for resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "kubeconfig_path" {
+  description = "Path to Kubernetes config file"
+  type        = string
+  default     = "~/.kube/config"
+}
+
+variable "monitoring_namespace" {
+  description = "Namespace for monitoring stack"
+  type        = string
+  default     = "monitoring"
+}
+
+variable "metrics_retention_days" {
+  description = "Prometheus metrics retention period in days"
+  type        = number
+}
+
+variable "trace_retention_days" {
+  description = "Trace retention period in days"
+  type        = number
+}
+
+variable "log_bucket_name" {
+  description = "S3 bucket name for logs"
+  type        = string
+}
+
+variable "log_retention_days" {
+  description = "Log retention period in days"
+  type        = number
+}
+
+variable "api_uptime_target" {
+  description = "Uptime threshold percentage for API availability"
+  type        = number
+}
+
+variable "api_p95_latency_ms" {
+  description = "Alert threshold for p95 latency in milliseconds"
+  type        = number
+}
+
+variable "api_p99_latency_ms" {
+  description = "Alert threshold for p99 latency in milliseconds"
+  type        = number
+}
+
+variable "booking_success_target" {
+  description = "Booking success rate threshold percentage"
+  type        = number
+}


### PR DESCRIPTION
## Summary
- configure infrastructure using Terraform modules
- add observability module for Prometheus and Tempo
- add S3 log bucket with lifecycle
- create PrometheusRule alerts for API uptime, latency, and booking success

## Testing
- `flutter --version`
- `dart test --coverage` *(fails: Dart SDK 3.3.0 < required 3.4.0)*

------
https://chatgpt.com/codex/tasks/task_e_686a4cf8b84c83249abaf9b8676fe893