### PR TITLE
Add observability configs and snippets

### DIFF
--- a/docs/grafana_dashboard.json
+++ b/docs/grafana_dashboard.json
@@ -1,0 +1,64 @@
+{
+  "annotations": {"list": []},
+  "templating": {
+    "list": [
+      {"name": "dau_target", "type": "constant", "query": "${DAU_TARGET}"},
+      {"name": "wau_target", "type": "constant", "query": "${WAU_TARGET}"},
+      {"name": "api_availability_slo_percent", "type": "constant", "query": "${API_AVAILABILITY_SLO}"},
+      {"name": "api_p95_latency_ms", "type": "constant", "query": "${API_P95_LATENCY}"},
+      {"name": "api_p99_latency_ms", "type": "constant", "query": "${API_P99_LATENCY}"},
+      {"name": "booking_success_slo_percent", "type": "constant", "query": "${BOOKING_SUCCESS_SLO}"},
+      {"name": "peak_sessions_target", "type": "constant", "query": "${PEAK_SESSIONS}"},
+      {"name": "incident_mttr_target", "type": "constant", "query": "${INCIDENT_MTTR}"},
+      {"name": "incident_mttd_target", "type": "constant", "query": "${INCIDENT_MTTD}"}
+    ]
+  },
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Daily Active Users",
+      "targets": [{"expr": "dau"}],
+      "fieldConfig": {"defaults": {}, "overrides": []}
+    },
+    {
+      "type": "timeseries",
+      "title": "Weekly Active Users",
+      "targets": [{"expr": "wau"}],
+      "fieldConfig": {"defaults": {}, "overrides": []}
+    },
+    {
+      "type": "gauge",
+      "title": "Peak Concurrent Sessions",
+      "targets": [{"expr": "peak_concurrent_sessions"}],
+      "options": {"reduceOptions": {"calcs": ["max"]}},
+      "fieldConfig": {"defaults": {}, "overrides": []}
+    },
+    {
+      "type": "heatmap",
+      "title": "API Latency Heatmap",
+      "targets": [{"expr": "histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m]))"}],
+      "fieldConfig": {"defaults": {}, "overrides": []}
+    },
+    {
+      "type": "timeseries",
+      "title": "Booking Success Rate",
+      "targets": [{"expr": "booking_success_rate"}],
+      "fieldConfig": {"defaults": {}, "overrides": []}
+    },
+    {
+      "type": "stat",
+      "title": "Incident MTTR",
+      "targets": [{"expr": "incident_mttr"}],
+      "fieldConfig": {"defaults": {}, "overrides": []}
+    },
+    {
+      "type": "stat",
+      "title": "Incident MTTD",
+      "targets": [{"expr": "incident_mttd"}],
+      "fieldConfig": {"defaults": {}, "overrides": []}
+    }
+  ],
+  "schemaVersion": 36,
+  "title": "App Observability",
+  "version": 1
+}

--- a/docs/observability_snippets.md
+++ b/docs/observability_snippets.md
@@ -1,0 +1,110 @@
+# Observability Instrumentation Snippets
+
+This document provides sample code to emit metrics for booking flows and expose Prometheus metrics endpoints.
+
+## Flutter / Dart
+
+```dart
+import 'package:prometheus_client/formatters.dart' as prometheus;
+import 'package:prometheus_client/prometheus_client.dart';
+import 'dart:io';
+
+final bookingSuccessTotal = Counter(
+  name: 'booking_success_total',
+  help: 'Total successful bookings',
+);
+final bookingAttemptTotal = Counter(
+  name: 'booking_attempt_total',
+  help: 'Total booking attempts',
+);
+final requestDuration = Histogram(
+  name: 'http_request_duration_seconds',
+  help: 'Request latency',
+  buckets: [0.1, 0.3, 0.5, 1, 2, 5],
+);
+
+/// Call when a booking is attempted
+void recordBookingAttempt() {
+  bookingAttemptTotal.inc();
+}
+
+/// Call when a booking succeeds
+void recordBookingSuccess() {
+  bookingSuccessTotal.inc();
+}
+
+/// Wrap HTTP requests to record timing
+Future<T> trackRequest<T>(String path, Future<T> Function() f) async {
+  final timer = requestDuration.startTimer();
+  try {
+    return await f();
+  } finally {
+    timer.observeDuration();
+  }
+}
+
+/// Simple /metrics handler
+Future<void> serveMetrics() async {
+  final server = await HttpServer.bind(InternetAddress.anyIPv4, 8081);
+  server.listen((request) {
+    if (request.uri.path == '/metrics') {
+      final body = prometheus.render();
+      request.response
+        ..headers.contentType = ContentType.text
+        ..write(body)
+        ..close();
+    } else {
+      request.response.statusCode = HttpStatus.notFound;
+      request.response.close();
+    }
+  });
+}
+```
+
+Placeholders for SLO thresholds can be injected when configuring alerts.
+
+## Node.js (Express)
+
+```javascript
+const express = require('express');
+const client = require('prom-client');
+const app = express();
+const collectDefaultMetrics = client.collectDefaultMetrics;
+collectDefaultMetrics();
+
+const bookingSuccessTotal = new client.Counter({
+  name: 'booking_success_total',
+  help: 'Total successful bookings',
+});
+const bookingAttemptTotal = new client.Counter({
+  name: 'booking_attempt_total',
+  help: 'Total booking attempts',
+});
+const requestDuration = new client.Histogram({
+  name: 'http_request_duration_seconds',
+  help: 'Request latency',
+  buckets: [0.1, 0.3, 0.5, 1, 2, 5],
+});
+
+app.use((req, res, next) => {
+  const end = requestDuration.startTimer();
+  res.on('finish', () => end());
+  next();
+});
+
+app.post('/book', (req, res) => {
+  bookingAttemptTotal.inc();
+  // Booking logic here
+  bookingSuccessTotal.inc();
+  res.send('ok');
+});
+
+app.get('/metrics', async (req, res) => {
+  res.set('Content-Type', client.register.contentType);
+  res.end(await client.register.metrics());
+});
+
+app.listen(3000);
+```
+
+Threshold values such as `api_p95_latency_ms` should be referenced from configuration when creating alert rules.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -39,23 +39,23 @@ provider "helm" {
 }
 
 module "observability" {
-  source                = "./modules/observability"
-  namespace             = var.monitoring_namespace
-  metrics_retention_days = var.metrics_retention_days
-  trace_retention_days   = var.trace_retention_days
+  source                   = "./modules/observability"
+  namespace                = var.monitoring_namespace
+  metrics_retention_period = var.metrics_retention_period
+  trace_retention_period   = var.trace_retention_period
 }
 
 module "log_bucket" {
-  source            = "./modules/log_bucket"
-  bucket_name       = var.log_bucket_name
-  log_retention_days = var.log_retention_days
+  source               = "./modules/log_bucket"
+  bucket_name          = var.log_bucket_name
+  log_retention_period = var.log_retention_period
 }
 
 module "alerts" {
-  source                 = "./modules/alerts"
-  namespace              = var.monitoring_namespace
-  api_uptime_target      = var.api_uptime_target
-  api_p95_latency_ms     = var.api_p95_latency_ms
-  api_p99_latency_ms     = var.api_p99_latency_ms
-  booking_success_target = var.booking_success_target
+  source                      = "./modules/alerts"
+  namespace                   = var.monitoring_namespace
+  api_availability_slo_percent = var.api_availability_slo_percent
+  api_p95_latency_ms          = var.api_p95_latency_ms
+  api_p99_latency_ms          = var.api_p99_latency_ms
+  booking_success_slo_percent = var.booking_success_slo_percent
 }

--- a/terraform/modules/alerts/main.tf
+++ b/terraform/modules/alerts/main.tf
@@ -2,7 +2,7 @@ data "template_file" "api_availability" {
   template = file("${path.module}/api_availability.yaml.tmpl")
   vars = {
     namespace         = var.namespace
-    api_uptime_target = var.api_uptime_target
+    api_uptime_target = var.api_availability_slo_percent
   }
 }
 
@@ -27,7 +27,7 @@ data "template_file" "booking_success" {
   template = file("${path.module}/booking_success.yaml.tmpl")
   vars = {
     namespace              = var.namespace
-    booking_success_target = var.booking_success_target
+    booking_success_target = var.booking_success_slo_percent
   }
 }
 

--- a/terraform/modules/alerts/variables.tf
+++ b/terraform/modules/alerts/variables.tf
@@ -3,7 +3,7 @@ variable "namespace" {
   type        = string
 }
 
-variable "api_uptime_target" {
+variable "api_availability_slo_percent" {
   description = "Target uptime percentage for API"
   type        = number
 }
@@ -18,7 +18,7 @@ variable "api_p99_latency_ms" {
   type        = number
 }
 
-variable "booking_success_target" {
+variable "booking_success_slo_percent" {
   description = "Booking success rate threshold percentage"
   type        = number
 }

--- a/terraform/modules/log_bucket/main.tf
+++ b/terraform/modules/log_bucket/main.tf
@@ -10,7 +10,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "log_lifecycle" {
     status = "Enabled"
 
     expiration {
-      days = var.log_retention_days
+      days = var.log_retention_period
     }
   }
 }

--- a/terraform/modules/log_bucket/variables.tf
+++ b/terraform/modules/log_bucket/variables.tf
@@ -3,7 +3,7 @@ variable "bucket_name" {
   type        = string
 }
 
-variable "log_retention_days" {
+variable "log_retention_period" {
   description = "Number of days to retain logs"
   type        = number
 }

--- a/terraform/modules/observability/main.tf
+++ b/terraform/modules/observability/main.tf
@@ -1,7 +1,3 @@
-locals {
-  metrics_retention_str = format("%dd", var.metrics_retention_days)
-  trace_retention_str   = format("%dd", var.trace_retention_days)
-}
 
 resource "helm_release" "kube_prometheus_stack" {
   name       = "kube-prometheus-stack"
@@ -13,7 +9,7 @@ resource "helm_release" "kube_prometheus_stack" {
     yamlencode({
       prometheus = {
         prometheusSpec = {
-          retention = local.metrics_retention_str
+          retention = var.metrics_retention_period
         }
       }
     })
@@ -29,7 +25,7 @@ resource "helm_release" "tempo" {
   values = [
     yamlencode({
       retention = {
-        time = local.trace_retention_str
+        time = var.trace_retention_period
       }
     })
   ]

--- a/terraform/modules/observability/variables.tf
+++ b/terraform/modules/observability/variables.tf
@@ -3,12 +3,12 @@ variable "namespace" {
   type        = string
 }
 
-variable "metrics_retention_days" {
-  description = "Retention time for Prometheus metrics in days"
-  type        = number
+variable "metrics_retention_period" {
+  description = "Prometheus metrics retention period (e.g. 14d)"
+  type        = string
 }
 
-variable "trace_retention_days" {
-  description = "Retention time for traces in days"
-  type        = number
+variable "trace_retention_period" {
+  description = "Trace retention period (e.g. 7d)"
+  type        = string
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,14 +16,14 @@ variable "monitoring_namespace" {
   default     = "monitoring"
 }
 
-variable "metrics_retention_days" {
-  description = "Prometheus metrics retention period in days"
-  type        = number
+variable "metrics_retention_period" {
+  description = "Prometheus metrics retention period (e.g. 14d)"
+  type        = string
 }
 
-variable "trace_retention_days" {
-  description = "Trace retention period in days"
-  type        = number
+variable "trace_retention_period" {
+  description = "Trace retention period (e.g. 7d)"
+  type        = string
 }
 
 variable "log_bucket_name" {
@@ -31,27 +31,27 @@ variable "log_bucket_name" {
   type        = string
 }
 
-variable "log_retention_days" {
+variable "log_retention_period" {
   description = "Log retention period in days"
   type        = number
 }
 
-variable "api_uptime_target" {
-  description = "Uptime threshold percentage for API availability"
+variable "api_availability_slo_percent" {
+  description = "Target uptime percentage for API availability"
   type        = number
 }
 
 variable "api_p95_latency_ms" {
-  description = "Alert threshold for p95 latency in milliseconds"
+  description = "p95 latency threshold in milliseconds"
   type        = number
 }
 
 variable "api_p99_latency_ms" {
-  description = "Alert threshold for p99 latency in milliseconds"
+  description = "p99 latency threshold in milliseconds"
   type        = number
 }
 
-variable "booking_success_target" {
+variable "booking_success_slo_percent" {
   description = "Booking success rate threshold percentage"
   type        = number
 }


### PR DESCRIPTION
## Summary
- rename observability variables to match SLO inputs
- create alerting rules with new variable names
- expose log retention and Prometheus retention periods
- add instrumentation snippets for Dart/Node
- provide starter Grafana dashboard JSON

## Testing
- `dart test --coverage` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a54d4c4e88324bf6ad8798d54c637