### PR TITLE
Fix CI dependency fetching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      # Cache Dart pub packages between runs
+      - name: Cache Pub dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-dart-${{ hashFiles('**/pubspec.yaml') }}
+
+      # Fetch Dart & Flutter dependencies
+      - name: Install Dart & Flutter deps
+        run: |
+          dart pub get
+          flutter pub get
+
       - name: Setup Dart
         uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
         with:
@@ -20,6 +34,5 @@ jobs:
           cache: true
       - run: flutter --version
       - run: dart --version
-      - run: flutter pub get
       - run: flutter analyze
       - run: dart test --coverage


### PR DESCRIPTION
## Summary
- speed up CI by caching `~/.pub-cache`
- fetch dependencies via `dart pub get` & `flutter pub get` before tests

## Testing
- `dart pub get` *(fails: domain is not in allowlist)*
- `flutter pub get` *(fails: domain is not in allowlist)*
- `firebase emulators:start --only auth,firestore,storage` *(fails: Error: download failed, status 403: Domain forbidden)*
- `dart test --coverage` *(fails: current Dart SDK version is 3.3.0; requires >=3.4.0)*

------
https://chatgpt.com/codex/tasks/task_e_686a63f1ef448324beffe7c775d44bb6