### PR TITLE
Automate firebase hosting deployment on main push

### DIFF
--- a/.github/workflows/firebase_hosting.yml
+++ b/.github/workflows/firebase_hosting.yml
@@ -1,0 +1,27 @@
+name: Deploy to Firebase Hosting
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Deploy to Firebase Hosting
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: firebase deploy --only hosting


### PR DESCRIPTION
Add GitHub Actions workflow to automatically deploy to Firebase Hosting on `main` branch pushes.