### PR TITLE
Check admin page readiness

### DIFF
--- a/lib/features/admin/admin_broadcast_screen.dart
+++ b/lib/features/admin/admin_broadcast_screen.dart
@@ -644,7 +644,7 @@ class _AdminBroadcastScreenState extends ConsumerState<AdminBroadcastScreen> {
     }
 
     try {
-      final service = ref.read(broadcastServiceProvider);
+      final service = ref.read(adminBroadcastServiceProvider);
       final count = await service.estimateTargetAudience(_filters);
       setState(() {
         _estimatedRecipients = count;
@@ -794,7 +794,7 @@ class _AdminBroadcastScreenState extends ConsumerState<AdminBroadcastScreen> {
         estimatedRecipients: _estimatedRecipients,
       );
 
-      final service = ref.read(broadcastServiceProvider);
+      final service = ref.read(adminBroadcastServiceProvider);
       await service.createBroadcastMessage(message);
 
       // Clear form and media
@@ -824,7 +824,7 @@ class _AdminBroadcastScreenState extends ConsumerState<AdminBroadcastScreen> {
     final l10n = AppLocalizations.of(context);
 
     try {
-      final service = ref.read(broadcastServiceProvider);
+      final service = ref.read(adminBroadcastServiceProvider);
       await service.sendBroadcastMessage(messageId);
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/admin/admin_dashboard_screen.dart
+++ b/lib/features/admin/admin_dashboard_screen.dart
@@ -28,7 +28,7 @@ class _AdminDashboardScreenState extends ConsumerState<AdminDashboardScreen>
   @override
   void initState() {
     super.initState();
-    final _tabController = TabController(length: 4, vsync: this);
+    _tabController = TabController(length: 4, vsync: this);
     _tabController.addListener(() {
       setState(() {
         _selectedIndex = _tabController.index;

--- a/lib/providers/admin_provider.dart
+++ b/lib/providers/admin_provider.dart
@@ -31,7 +31,7 @@ final isAdminProvider = FutureProvider<bool>((ref) async {
 
 /// Provider for broadcast messages list
 final broadcastMessagesProvider = FutureProvider<List<AdminBroadcastMessage>>((ref) async {
-  final broadcastService = ref.watch(broadcastServiceProvider);
+  final broadcastService = ref.watch(adminBroadcastServiceProvider);
   final isAdmin = await ref.watch(isAdminProvider.future);
   
   if (!isAdmin) {

--- a/lib/services/broadcast_notification_handler.dart
+++ b/lib/services/broadcast_notification_handler.dart
@@ -261,7 +261,7 @@ class BroadcastNotificationHandler {
 final broadcastNotificationHandlerProvider = Provider<BroadcastNotificationHandler>(
   (ref) {
     final handler = BroadcastNotificationHandler.instance;
-    final broadcastService = ref.read(broadcastServiceProvider);
+    final broadcastService = ref.read(adminBroadcastServiceProvider);
     handler.initialize(broadcastService);
     return handler;
   },

--- a/lib/services/broadcast_scheduler_service.dart
+++ b/lib/services/broadcast_scheduler_service.dart
@@ -77,7 +77,7 @@ class BroadcastSchedulerService {
 final broadcastSchedulerServiceProvider = Provider<BroadcastSchedulerService>(
   (ref) {
     final service = BroadcastSchedulerService.instance;
-    final broadcastService = ref.read(broadcastServiceProvider);
+    final broadcastService = ref.read(adminBroadcastServiceProvider);
     service.initialize(broadcastService);
     return service;
   },


### PR DESCRIPTION
Fix admin page provider naming conflicts and tab controller initialization.

The `broadcastServiceProvider` was causing naming conflicts when referenced in admin-specific files, leading to compilation issues. Additionally, the `_tabController` in `AdminDashboardScreen` was incorrectly declared as a local variable, preventing proper tab functionality.