### PR TITLE
Sync and qa app-oint system

### DIFF
--- a/flutter_install.sh
+++ b/flutter_install.sh
@@ -1,0 +1,1 @@
+<?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: flutter_infra_release/releases/stable/linux/flutter_linux_3.32.0-stable.tar.xz.sha256</Details></Error>


### PR DESCRIPTION
Add `flutter_install.sh` containing an error log from a failed Flutter installation attempt during environment setup.