### PR TITLE
Digitalocean token validation and persistence

### DIFF
--- a/test_curl.sh
+++ b/test_curl.sh
@@ -1,0 +1,1 @@
+curl -s -H "Authorization: Bearer dop_v1_4051a4609af65235ca0ca866f5d410d772e338ddcc642202ad3053450ttps://api.digitalocean.com/v2count

--- a/test_do.py
+++ b/test_do.py
@@ -1,0 +1,34 @@
+import requests
+import json
+
+token =dop_v1_4051a4609af65235ca0ca866f5d410772e338cc64222ad303450url = "https://api.digitalocean.com/v2account"
+headers = {
+    Authorization: fBearer {token}",
+   Content-Type":application/json"
+}
+
+print("Testing DigitalOcean token...")
+print(fToken: {token[:20}...")
+print(f"URL: {url}")
+print()
+
+try:
+    response = requests.get(url, headers=headers)
+    
+    print(f"HTTP Status: {response.status_code}")
+    print("Response Headers:")
+    for key, value in response.headers.items():
+        print(f"  {key}: {value}")
+    
+    print("\nResponse Body:)if response.status_code ==20   data = response.json()
+        print(json.dumps(data, indent=2))
+        print("\n✅ Token is VALID")
+    elif response.status_code == 401:
+        print("❌ Token is INVALID - Unauthorized")
+        print(response.text)
+    else:
+        print(f"❌ Unexpected status code: {response.status_code}")
+        print(response.text)
+        
+except Exception as e:
+    print(f"❌ Error making request: {e}")

--- a/test_do.sh
+++ b/test_do.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+TOKEN="dop_v1451609af65235ca0ca866f5d410d772338ddcc642202d3053450URL="https://api.digitalocean.com/v2nt"
+
+echo "Testing DigitalOcean token..."
+echo Token: ${TOKEN:0:20}..."
+echo "URL: $URL
+response=$(curl -s -w "HTTP_STATUS:%{http_code}" -H "Authorization: Bearer $TOKEN" "$URL")
+http_status=$(echo $response" | grep -oHTTP_STATUS:[0-9*" | cut -d: -f2)
+body=$(echo$response" | sed s/HTTP_STATUS:[0-9]*//')
+
+echo "HTTP Status: $http_status"
+echo Response: $body


### PR DESCRIPTION
Add scripts to validate a DigitalOcean API token by making a test request to the `/v2/account` endpoint.

This PR includes `test_do.py` which successfully performed the token validation, along with `test_curl.sh` and `test_do.sh` from earlier attempts during the session.