### PR TITLE
Changes from background agent bc-96872851-429c-4bce-9e7e-b4893f02390b

### DIFF
--- a/lib/utils/datetime_converter.dart
+++ b/lib/utils/datetime_converter.dart
@@ -1,7 +1,6 @@
 import 'dart:core';
 import 'package:json_annotation/json_annotation.dart';
 
-@JsonSerializable()
 class DateTimeConverter implements JsonConverter<DateTime, String> {
   const DateTimeConverter();
 


### PR DESCRIPTION
Remove incorrect `@JsonSerializable()` annotation from `DateTimeConverter` to resolve `build_runner` issues.

The `build_runner` was failing to generate necessary `.g.dart` and `.freezed.dart` files for various models, leading to numerous "Method not found" and "getter isn't defined" errors. This specific change addresses one identified root cause: applying `@JsonSerializable()` to a `JsonConverter` class is incorrect and was likely preventing successful code generation across the project. This fix is a prerequisite for `build_runner` to function correctly.

---

[Open in Web](https://cursor.com/agents?id=bc-96872851-429c-4bce-9e7e-b4893f02390b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-96872851-429c-4bce-9e7e-b4893f02390b) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)